### PR TITLE
fix events#one by providing the correct callback to unbind

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -48,8 +48,8 @@ window.Events = window.Events || (function() {
   //     object.one 'groundTouch', gameOver
   //
   Events.prototype.one = function(ev, callback) {
-    this.bind(ev, function() {
-      this.unbind(ev, callback);
+    this.bind(ev, function _callback() {
+      this.unbind(ev, _callback);
       callback.apply(this, arguments);
     });
   };

--- a/test/specs/events.spec.js
+++ b/test/specs/events.spec.js
@@ -34,6 +34,7 @@ describe("Events", function() {
       cb = jasmine.createSpy('test');
       this.obj.one('test', cb);
       this.obj.trigger('test');
+      this.obj.trigger('test');
       expect(cb.callCount).toBe(1);
     });
 


### PR DESCRIPTION
Found a little mistake in the Events#one method. Currently it calls the Events#unbind with the callback that #one gets called with, not the wrapper that actually binds for the event.
Hope it helps and the pull request is ok like this. I changed the test accordingly.
