### PR TITLE
V0.4 peanuts flexible events module

### DIFF
--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -1,4 +1,5 @@
 /* exported hoodieAccount */
+/* global hoodieEvents */
 
 // Hoodie.Account
 // ================
@@ -21,6 +22,8 @@ function hoodieAccount (hoodie) {
   // default couchDB user doc prefix
   var userDocPrefix = 'org.couchdb.user';
 
+  // add events API
+  hoodieEvents(hoodie, { context: account, namespace: 'account'});
 
   // Authenticate
   // --------------
@@ -252,32 +255,6 @@ function hoodieAccount (hoodie) {
     }
     hoodie.remote.disconnect();
     return sendSignOutRequest().then(cleanupAndTriggerSignOut);
-  };
-
-
-  // On
-  // ---
-
-  // shortcut for `hoodie.on`
-  //
-  account.on = function on(eventName, cb) {
-    eventName = eventName.replace(/(^| )([^ ]+)/g, '$1account:$2');
-    return hoodie.on(eventName, cb);
-  };
-
-
-  // Trigger
-  // ---
-
-  // shortcut for `hoodie.trigger`
-  //
-  account.trigger = function trigger() {
-    var eventName, parameters;
-
-    eventName = arguments[0],
-    parameters = 2 <= arguments.length ? Array.prototype.slice.call(arguments, 1) : [];
-
-    hoodie.trigger.apply(hoodie, ['account:' + eventName].concat(Array.prototype.slice.call(parameters)));
   };
 
 

--- a/src/hoodie/scoped_store.js
+++ b/src/hoodie/scoped_store.js
@@ -1,5 +1,5 @@
 /* exported hoodieScopedStoreApi */
-/* jshint unused: false */
+/* global hoodieEvents */
 
 // scoped Store
 // ============
@@ -19,6 +19,10 @@ function hoodieScopedStoreApi(hoodie, storeApi, options) {
 
   // scoped by type only
   if (! id) {
+
+    // add events
+    hoodieEvents(hoodie, { context: api, namespace: storeName + ':' + type });
+
     //
     api.save = function save(id, properties, options) {
       return storeApi.save(type, id, properties, options);
@@ -63,35 +67,14 @@ function hoodieScopedStoreApi(hoodie, storeApi, options) {
     api.removeAll = function removeAll(options) {
       return storeApi.removeAll(type, options);
     };
-
-    //
-    api.trigger = function trigger() {
-      var eventName = arguments[0];
-      var parameters = 2 <= arguments.length ? Array.prototype.slice.call(arguments, 1) : [];
-      var prefix = storeName + ':' + type;
-
-      return hoodie.trigger.apply(hoodie, [prefix + ':' + eventName].concat(Array.prototype.slice.call(parameters)));
-    };
-
-    //
-    api.on = function on(eventName, data) {
-      var prefix = storeName + ':' + type;
-      eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
-
-      return hoodie.on(eventName, data);
-    };
-
-    //
-    api.unbind = function unbind(eventName, callback) {
-      var prefix = storeName + ':' + type;
-
-      eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
-      return hoodie.unbind(eventName, callback);
-    };
   }
 
   // scoped by both: type & id
   if (id) {
+
+    // add events
+    hoodieEvents(hoodie, { context: api, namespace: storeName + ':' + type + ':' + id });
+
     //
     api.save = function save(properties, options) {
       return storeApi.save(type, id, properties, options);
@@ -110,31 +93,6 @@ function hoodieScopedStoreApi(hoodie, storeApi, options) {
     //
     api.remove = function remove(options) {
       return storeApi.remove(type, id, options);
-    };
-
-    //
-    api.trigger = function trigger() {
-      var eventName = arguments[0];
-      var parameters = 2 <= arguments.length ? Array.prototype.slice.call(arguments, 1) : [];
-      var prefix = storeName + ':' + type + ':' + id;
-
-      return hoodie.trigger.apply(hoodie, [prefix + ':' + eventName].concat(Array.prototype.slice.call(parameters)));
-    };
-
-    //
-    api.on = function on(eventName, data) {
-      var prefix = storeName + ':' + type + ':' + id;
-      eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
-
-      return hoodie.on(eventName, data);
-    };
-
-    //
-    api.unbind = function unbind(eventName, callback) {
-      var prefix = storeName + ':' + type + ':' + id;
-
-      eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
-      return hoodie.unbind(eventName, callback);
     };
   }
 

--- a/src/hoodie/store.js
+++ b/src/hoodie/store.js
@@ -1,4 +1,4 @@
-/* global hoodieScopedStoreApi */
+/* global hoodieScopedStoreApi, hoodieEvents */
 /* exported hoodieStoreApi */
 
 // Store
@@ -56,6 +56,9 @@ function hoodieStoreApi(hoodie, options) {
     var scopedOptions = $.extend(true, {type: type, id: id}, options);
     return hoodieScopedStoreApi(hoodie, api, scopedOptions);
   };
+
+  // add event API
+  hoodieEvents(hoodie, { context: api, namespace: storeName });
 
 
   // Validate
@@ -399,44 +402,6 @@ function hoodieStoreApi(hoodie, options) {
     return $.extend(promiseApi, methods);
   };
 
-
-
-  // trigger
-  // ---------
-
-  // proxies to hoodie.trigger
-  api.trigger = function trigger() {
-    var eventName = arguments[0];
-    var parameters = 2 <= arguments.length ? Array.prototype.slice.call(arguments, 1) : [];
-    var prefix = storeName;
-
-    return hoodie.trigger.apply(hoodie, [prefix + ':' + eventName].concat(Array.prototype.slice.call(parameters)));
-  };
-
-
-  // on
-  // ---------
-
-  // proxies to hoodie.on
-  api.on = function on(eventName, data) {
-    var prefix = storeName;
-
-    eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
-
-    return hoodie.on(eventName, data);
-  };
-
-
-  // unbind
-  // ---------
-
-  // proxies to hoodie.unbind
-  api.unbind = function unbind(eventName, callback) {
-    var prefix = storeName;
-
-    eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
-    return hoodie.unbind(eventName, callback);
-  };
 
 
   // required backend methods

--- a/test/mocks/events.mock.js
+++ b/test/mocks/events.mock.js
@@ -1,0 +1,7 @@
+var Mocks = window.Mocks || {};
+Mocks.EventsApi = function (hoodie, options) {
+  options.context.trigger = sinon.stub();
+  options.context.on = sinon.stub();
+  options.context.one = sinon.stub();
+  options.context.unbind = sinon.stub();
+};

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -26,6 +26,7 @@ describe('hoodie.account', function () {
     }.bind(this);
 
     this.clock = this.sandbox.useFakeTimers(0); // '1970-01-01 00:00:00'
+    this.sandbox.stub(window, 'hoodieEvents', Mocks.EventsApi);
 
     hoodieAccount(this.hoodie);
     this.account = this.hoodie.account;
@@ -51,7 +52,7 @@ describe('hoodie.account', function () {
 
         it('should send a GET /_session', function () {
           this.account.authenticate();
-          expect(this.account.request.calledWith('GET', '/_session')).to.be.ok();
+          expect(this.account.request).to.be.calledWith('GET', '/_session');
         });
 
         it('should not send multiple GET /_session requests', function () {
@@ -129,12 +130,12 @@ describe('hoodie.account', function () {
 
             it('should not set _account.username config', function () {
               // because it's already 'joe@example.com'
-              expect(this.hoodie.config.set.calledWith('_account.username', 'joe@example.com')).to.not.be.ok();
+              expect(this.hoodie.config.set).to.not.be.calledWith('_account.username', 'joe@example.com');
             });
 
             it('should set account.ownerHash', function () {
               // because it's already 'user_hash'
-              expect(this.hoodie.config.set.calledWith('_account.ownerHash', 'user_hash')).to.not.be.ok();
+              expect(this.hoodie.config.set).to.not.be.calledWith('_account.ownerHash', 'user_hash');
             });
           }); // returns valid session info for joe@example.com
 
@@ -149,8 +150,8 @@ describe('hoodie.account', function () {
               expect(this.promise.state()).to.eql('rejected');
             });
 
-            it('should trigger an `account:error:unauthenticated` event', function () {
-              expect(this.hoodie.trigger.calledWith('account:error:unauthenticated')).to.be.ok();
+            it('should trigger an `error:unauthenticated` event', function () {
+              expect(this.account.trigger).to.be.calledWith('error:unauthenticated');
             });
           }); // session is invalid
         }); // authentication request is successful and
@@ -624,9 +625,8 @@ describe('hoodie.account', function () {
             this.clock.tick(300); // do the delayed sign in
           });
 
-          it('should trigger `account:signup` event', function () {
-
-            expect(this.hoodie.trigger.calledWith('account:signup', 'joe@example.com')).to.be.ok();
+          it('should trigger `signup` event', function () {
+            expect(this.account.trigger).to.be.calledWith('signup', 'joe@example.com');
           });
 
           it('should sign in', function () {
@@ -779,18 +779,18 @@ describe('hoodie.account', function () {
           this.requestDefer.resolve(this.response);
         });
 
-        it('should not trigger `account:cleanup` event', function () {
+        it('should not trigger `cleanup` event', function () {
           this.account.signIn('joe@example.com', 'secret');
-          expect(this.hoodie.trigger.calledWith('account:cleanup')).to.not.be.ok();
+          expect(this.account.trigger).to.not.be.calledWith('cleanup');
         });
 
         it('should not trigger signin events', function () {
-          expect(this.hoodie.trigger.calledWith('account:signin', 'joe@example.com')).to.not.be.ok();
-          expect(this.hoodie.trigger.calledWith('account:signin:anonymous', 'joe@example.com')).to.not.be.ok();
+          expect(this.account.trigger).to.not.be.calledWith('signin', 'joe@example.com');
+          expect(this.account.trigger).to.not.be.calledWith('signin:anonymous', 'joe@example.com');
         });
 
         it('should trigger reauthenticated event', function () {
-          expect(this.hoodie.trigger.calledWith('account:reauthenticated', 'joe@example.com')).to.be.ok();
+          expect(this.account.trigger).to.be.calledWith('reauthenticated', 'joe@example.com');
         });
 
       }); // signIn successful
@@ -860,7 +860,7 @@ describe('hoodie.account', function () {
             this.sandbox.spy(this.hoodie.config, 'set');
 
             delete this.account.username;
-            this.hoodie.trigger.reset();
+            this.account.trigger.reset();
           });
 
           _and('user has an anonyomous account', function () {
@@ -869,9 +869,9 @@ describe('hoodie.account', function () {
               this.sandbox.stub(this.account, 'hasAnonymousAccount').returns(true);
             });
 
-            it('should trigger `account:signin:anonymous` event', function () {
+            it('should trigger `signin:anonymous` event', function () {
               this.account.signIn('joe@example.com', 'secret');
-              expect(this.hoodie.trigger.calledWith('account:signin:anonymous', 'joe@example.com')).to.be.ok();
+              expect(this.account.trigger).to.be.calledWith('signin:anonymous', 'joe@example.com');
             });
           }); // user has an anonyomous account
 
@@ -881,9 +881,9 @@ describe('hoodie.account', function () {
               this.sandbox.stub(this.account, 'hasAnonymousAccount').returns(false);
             });
 
-            it('should trigger `account:signin` event', function () {
+            it('should trigger `signin` event', function () {
               this.account.signIn('joe@example.com', 'secret');
-              expect(this.hoodie.trigger.calledWith('account:signin', 'joe@example.com')).to.be.ok();
+              expect(this.account.trigger).to.be.calledWith('signin', 'joe@example.com');
             });
 
           }); // user has a manual account
@@ -892,7 +892,7 @@ describe('hoodie.account', function () {
             this.account.signIn('joe@example.com', 'secret');
 
             expect(this.account.username).to.eql('joe@example.com');
-            expect(this.hoodie.config.set.calledWith('_account.username', 'joe@example.com')).to.be.ok();
+            expect(this.hoodie.config.set).to.be.calledWith('_account.username', 'joe@example.com');
           });
 
           it('should set @ownerHash', function () {
@@ -900,8 +900,8 @@ describe('hoodie.account', function () {
             this.account.signIn('joe@example.com', 'secret');
 
             expect(this.account.ownerHash).to.eql('user_hash');
-            expect(this.hoodie.config.set.calledWith('_account.ownerHash', 'user_hash')).to.be.ok();
-            expect(this.hoodie.config.set.calledWith('createdBy', 'user_hash')).to.be.ok();
+            expect(this.hoodie.config.set).to.be.calledWith('_account.ownerHash', 'user_hash');
+            expect(this.hoodie.config.set).to.be.calledWith('createdBy', 'user_hash');
           });
 
           it('should fetch the _users doc', function () {
@@ -963,7 +963,7 @@ describe('hoodie.account', function () {
           it('should fetch user doc without setting @username', function () {
             this.account.signIn('joe@example.com', 'secret');
 
-            expect(this.account.fetch.calledWith('joe@example.com')).to.be.ok();
+            expect(this.account.fetch).to.be.calledWith('joe@example.com');
             expect(this.account.username).to.be(undefined);
           });
 
@@ -1120,7 +1120,7 @@ describe('hoodie.account', function () {
 
         it('should sign in', function () {
           this.account.changePassword('currentSecret', 'newSecret');
-          expect(this.account.signIn.calledWith('joe@example.com', 'newSecret')).to.be.ok();
+          expect(this.account.signIn).to.be.calledWith('joe@example.com', 'newSecret');
         });
 
         _when('sign in successful', function () {
@@ -1184,11 +1184,11 @@ describe('hoodie.account', function () {
 
     _when('called with silent: true', function () {
 
-      it('should not trigger `account:signout` event', function () {
+      it('should not trigger `signout` event', function () {
         this.account.signOut({
           silent: true
         });
-        expect(this.hoodie.trigger.calledWith('account:signout')).to.not.be.ok();
+        expect(this.account.trigger).to.not.be.calledWith('signout');
       });
     }); // called with silent: true
 
@@ -1203,8 +1203,8 @@ describe('hoodie.account', function () {
         expect(this.hoodie.request.called).to.not.be.ok();
       });
 
-      it('should trigger `account:signout` event', function () {
-        expect(this.hoodie.trigger.calledWith('account:signout')).to.be.ok();
+      it('should trigger `signout` event', function () {
+        expect(this.account.trigger).to.be.calledWith('signout');
       });
 
       it('should generate new @ownerHash hash', function () {
@@ -1256,8 +1256,8 @@ describe('hoodie.account', function () {
           this.account.signOut();
         });
 
-        it('should trigger `account:signout` event', function () {
-          expect(this.hoodie.trigger.calledWith('account:signout')).to.be.ok();
+        it('should trigger `signout` event', function () {
+          expect(this.account.trigger).to.be.calledWith('signout');
         });
 
         it('should generate new @ownerHash hash', function () {
@@ -1326,26 +1326,6 @@ describe('hoodie.account', function () {
       });
     }); // _account.anonymousPassword is not set
   }); // #hasAnonymousAccount
-
-  describe('#on(event, callback)', function () {
-    beforeEach(function () {
-      this.sandbox.spy(this.hoodie, 'on');
-    });
-
-    it('should proxy to @hoodie.on() and namespace with account', function () {
-      var party = this.sandbox.spy();
-
-      this.account.on('funky', party);
-      expect(this.hoodie.on.calledWith('account:funky', party)).to.be.ok();
-    });
-
-    it('should namespace multiple events correctly', function () {
-      var cb = this.sandbox.spy();
-
-      this.account.on('super funky fresh', cb);
-      expect(this.hoodie.on.calledWith('account:super account:funky account:fresh', cb)).to.be.ok();
-    });
-  }); // #on
 
   describe('#db()', function () {
     _when('account.ownerHash is \'owner_hash123\'', function () {
@@ -1487,7 +1467,7 @@ describe('hoodie.account', function () {
           });
 
           it('should trigger signout event', function () {
-            expect(this.hoodie.trigger.calledWith('account:signout')).to.be.ok();
+            expect(this.account.trigger).to.be.calledWith('signout');
           });
 
           it('should clear config', function () {
@@ -1495,11 +1475,11 @@ describe('hoodie.account', function () {
           });
 
           it('should set config._account.ownerHash to new @ownerHash', function () {
-            expect(this.hoodie.config.set.calledWith('_account.ownerHash', 'newHash')).to.be.ok();
+            expect(this.hoodie.config.set).to.be.calledWith('_account.ownerHash', 'newHash');
           });
 
           it('should trigger clenaup event', function() {
-            expect(this.hoodie.trigger.calledWith('account:cleanup')).to.be.ok();
+            expect(this.account.trigger).to.be.calledWith('cleanup');
           });
         }); // destroy request succesful
       }); // fetch is successful
@@ -1549,7 +1529,7 @@ describe('hoodie.account', function () {
         });
 
         it('should not trigger signout event', function () {
-          expect(this.hoodie.trigger.calledWith('account:signout')).to.not.be.ok();
+          expect(this.account.trigger).to.not.be.calledWith('signout');
         });
 
         it('should not clear config', function () {
@@ -1582,7 +1562,7 @@ describe('hoodie.account', function () {
       });
 
       it('should trigger signout event', function () {
-        expect(this.hoodie.trigger.calledWith('account:signout')).to.be.ok();
+        expect(this.account.trigger).to.be.calledWith('signout');
       });
 
       it('should clear config', function () {
@@ -1637,7 +1617,7 @@ describe('hoodie.account', function () {
       });
 
       it('should generate a reset Password Id and store it locally', function () {
-        expect(this.hoodie.config.set.calledWith('_account.resetPasswordId', 'joe@example.com/uuid567')).to.be.ok();
+        expect(this.hoodie.config.set).to.be.calledWith('_account.resetPasswordId', 'joe@example.com/uuid567');
       });
 
       it('should send a PUT request to /_users/org.couchdb.user%3A%24passwordReset%2Fjoe%40example.com%2Fuuid567', function () {
@@ -1694,13 +1674,6 @@ describe('hoodie.account', function () {
       });
     }); // there is no pending password reset request
   }); // #resetPassword
-
-  describe('#trigger(event, arg1, arg2, ...)', function () {
-    it('should proxy to hoodie.trigger', function() {
-      this.account.trigger('say', 'funky', 'fresh');
-      expect(this.hoodie.trigger).to.be.calledWith('account:say', 'funky', 'fresh');
-    });
-  }); // #trigger
 
   describe('#changeUsername(currentPassword, newUsername)', function () {
     beforeEach(function () {

--- a/test/specs/hoodie/events.spec.js
+++ b/test/specs/hoodie/events.spec.js
@@ -3,55 +3,51 @@
 describe('Events', function() {
 
   beforeEach(function() {
-    this.obj = {};
-    hoodieEvents(this.obj);
+    this.hoodie = {}; // new Mocks.Hoodie();
+    hoodieEvents(this.hoodie);
   });
 
   describe('.bind(event, callback)', function() {
-
     it('should bind the passed callback to the passed event', function() {
       var cb = sinon.spy();
 
-      this.obj.bind('test', cb);
-      this.obj.trigger('test');
+      this.hoodie.bind('test', cb);
+      this.hoodie.trigger('test');
 
-      expect(cb.called).to.be.ok();
+      expect(cb).to.be.called();
     });
 
     it('should allow to pass multiple events', function() {
       var cb = sinon.spy();
 
-      this.obj.bind('test1 test2', cb);
-      this.obj.trigger('test1');
-      this.obj.trigger('test2');
+      this.hoodie.bind('test1 test2', cb);
+      this.hoodie.trigger('test1');
+      this.hoodie.trigger('test2');
 
       expect(cb.callCount).to.eql(2);
     });
-
-  });
+  }); // .bind(event, callback)
 
   describe('.one(event, callback)', function() {
-
     it('should bind passed callback to first occurence of passed event', function() {
       var cb = sinon.spy();
 
-      this.obj.one('test', cb);
-      this.obj.trigger('test');
+      this.hoodie.one('test', cb);
+      this.hoodie.trigger('test');
+      this.hoodie.trigger('test');
 
       expect(cb.callCount).to.eql(1);
     });
-
-  });
+  }); // .one(event, callback)
 
   describe('.trigger(event, args...)', function() {
-
     it('should call subscribed callbacks', function() {
       var cb1, cb2;
       cb1 = sinon.spy();
       cb2 = sinon.spy();
-      this.obj.bind('test', cb1);
-      this.obj.bind('test', cb2);
-      this.obj.trigger('test');
+      this.hoodie.bind('test', cb1);
+      this.hoodie.bind('test', cb2);
+      this.hoodie.trigger('test');
 
       expect(cb1.called).to.be.ok();
       expect(cb2.called).to.be.ok();
@@ -59,23 +55,21 @@ describe('Events', function() {
 
     it('should pass arguments', function() {
       var cb = sinon.spy();
-      this.obj.bind('test', cb);
-      this.obj.trigger('test', 'arg1', 'arg2', 'arg3');
+      this.hoodie.bind('test', cb);
+      this.hoodie.trigger('test', 'arg1', 'arg2', 'arg3');
 
-      expect(cb.calledWith('arg1', 'arg2', 'arg3')).to.be.ok();
+      expect(cb).to.be.calledWith('arg1', 'arg2', 'arg3');
     });
-
-  });
+  }); // .trigger(event, args...)
 
   describe('.unbind(event, callback)', function() {
-
     _when('callback passed', function() {
 
       it('should unsubscribe the callback', function() {
-        var cb= sinon.spy();
-        this.obj.bind('test', cb);
-        this.obj.unbind('test', cb);
-        this.obj.trigger('test');
+        var cb = sinon.spy();
+        this.hoodie.bind('test', cb);
+        this.hoodie.unbind('test', cb);
+        this.hoodie.trigger('test');
 
         expect(cb.callCount).to.eql(0);
       });
@@ -86,18 +80,105 @@ describe('Events', function() {
         var cb1, cb2;
         cb1 = sinon.spy();
         cb2 = sinon.spy();
-        this.obj.bind('test', cb1);
-        this.obj.bind('test', cb2);
-        this.obj.unbind('test');
-        this.obj.trigger('test');
+        this.hoodie.bind('test', cb1);
+        this.hoodie.bind('test', cb2);
+        this.hoodie.unbind('test');
+        this.hoodie.trigger('test');
 
         expect(cb1.callCount).to.eql(0);
         expect(cb2.callCount).to.eql(0);
       });
+    });
+  }); // .unbind(event, callback)
 
+  describe('options.context = obj & options.namespace = "funky"', function() {
+    beforeEach(function() {
+      this.context = {};
+      hoodieEvents(this.hoodie, { context: this.context, namespace: 'funky' });
     });
 
-  });
+    describe('.bind(event, callback)', function() {
+      it('should bind the passed callback to the passed event on context', function() {
+        var cb = sinon.spy();
 
+        this.context.bind('test', cb);
+        this.context.trigger('test');
+
+        expect(cb).to.be.called();
+      });
+
+      it('should bind the passed callback to the passed event namespaced by "funky"', function() {
+        var cb = sinon.spy();
+
+        this.hoodie.bind('funky:test', cb);
+        this.context.trigger('test');
+
+        expect(cb).to.be.called();
+      });
+    }); // .bind(event, callback)
+
+    describe('.one(event, callback)', function() {
+      it('should bind passed callback to first occurence of passed event on context', function() {
+        var cb = sinon.spy();
+
+        this.context.one('test', cb);
+        this.context.trigger('test');
+        this.context.trigger('test');
+
+        expect(cb.callCount).to.eql(1);
+      });
+
+      it('should bind passed callback to first occurence of passed event namespaced by "funky"', function() {
+        var cb = sinon.spy();
+
+        this.context.one('test', cb);
+        this.hoodie.trigger('funky:test');
+        this.hoodie.trigger('funky:test');
+
+        expect(cb.callCount).to.eql(1);
+      });
+    }); // .one(event, callback)
+
+    describe('.unbind(event, callback)', function() {
+      _when('callback passed', function() {
+        it('should unsubscribe the callback on context', function() {
+          var cb = sinon.spy();
+          this.context.bind('test', cb);
+          this.context.unbind('test', cb);
+          this.context.trigger('test');
+
+          expect(cb.callCount).to.eql(0);
+        });
+
+        it('should unsubscribe the callback namespaced by "funky"', function() {
+          var cb = sinon.spy();
+          this.context.bind('test', cb);
+          this.context.unbind('test', cb);
+          this.hoodie.trigger('funky:test');
+
+          expect(cb.callCount).to.eql(0);
+        });
+      });
+
+      _when('no callback passed', function() {
+        it('should unsubscribe all callbacks namespaced by "funky"', function() {
+          var cb1, cb2, cb3;
+          cb1 = sinon.spy();
+          cb2 = sinon.spy();
+          cb3 = sinon.spy();
+          this.hoodie.bind('funky:test', cb1);
+          this.hoodie.bind('funky:test', cb2);
+          this.hoodie.bind('test', cb3);
+          this.context.unbind();
+          this.context.trigger('test');
+          this.hoodie.trigger('test');
+
+          expect(cb1.callCount).to.eql(0);
+          expect(cb2.callCount).to.eql(0);
+          expect(cb3.callCount).to.eql(1);
+        });
+      });
+    }); // .unbind(event, callback)
+  });
 });
 

--- a/test/specs/hoodie/scoped_store.spec.js
+++ b/test/specs/hoodie/scoped_store.spec.js
@@ -5,6 +5,7 @@ describe('hoodieScopedStoreApi', function() {
   beforeEach(function() {
     this.hoodie = new Mocks.Hoodie();
     this.store = Mocks.StoreApi(this.hoodie);
+    this.sandbox.spy(window, 'hoodieEvents');
     this.options = Mocks.storeOptions('taskstore');
   });
 
@@ -59,24 +60,8 @@ describe('hoodieScopedStoreApi', function() {
       expect(this.store.removeAll).to.be.calledWith('task', {option: 'value'});
     });
 
-    it('scopes trigger method to type "task"', function() {
-      this.sandbox.spy(this.hoodie, 'trigger');
-      this.scopedStore.trigger('event');
-      expect(this.hoodie.trigger).to.be.calledWith('taskstore:task:event');
-    });
-
-    it('scopes on method to type "task"', function() {
-      this.sandbox.spy(this.hoodie, 'on');
-      var callback = function() {};
-      this.scopedStore.on('event1 event2', callback);
-      expect(this.hoodie.on).to.be.calledWith('taskstore:task:event1 taskstore:task:event2', callback);
-    });
-
-    it('scopes unbind method to type "task"', function() {
-      this.sandbox.spy(this.hoodie, 'unbind');
-      var callback = function() {};
-      this.scopedStore.unbind('event1 event2', callback);
-      expect(this.hoodie.unbind).to.be.calledWith('taskstore:task:event1 taskstore:task:event2', callback);
+    it('adds event API', function() {
+      expect(window.hoodieEvents).to.be.calledWith(this.hoodie, { context : this.scopedStore, namespace: 'taskstore:task' });
     });
   }); // 'when scoped by type only'
 
@@ -127,24 +112,8 @@ describe('hoodieScopedStoreApi', function() {
       expect(this.scopedStore.removeAll).to.be(undefined);
     });
 
-    it('scopes trigger method to type "task" & id "abc"', function() {
-      this.sandbox.spy(this.hoodie, 'trigger');
-      this.scopedStore.trigger('event');
-      expect(this.hoodie.trigger).to.be.calledWith('taskstore:task:abc:event');
-    });
-
-    it('scopes on method to type "task" & id "abc"', function() {
-      this.sandbox.spy(this.hoodie, 'on');
-      var callback = function() {};
-      this.scopedStore.on('event1 event2', callback);
-      expect(this.hoodie.on).to.be.calledWith('taskstore:task:abc:event1 taskstore:task:abc:event2', callback);
-    });
-
-    it('scopes unbind method to type "task" & id "abc"', function() {
-      this.sandbox.spy(this.hoodie, 'unbind');
-      var callback = function() {};
-      this.scopedStore.unbind('event1 event2', callback);
-      expect(this.hoodie.unbind).to.be.calledWith('taskstore:task:abc:event1 taskstore:task:abc:event2', callback);
+    it('adds event API', function() {
+      expect(window.hoodieEvents).to.be.calledWith(this.hoodie, { context : this.scopedStore, namespace: 'taskstore:task:abc' });
     });
   }); // 'when scoped by type only'
 });

--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -7,6 +7,7 @@ describe('hoodieStoreApi', function() {
     this.options = Mocks.storeOptions('funkstore');
     this.validate = sinon.stub();
     this.optionsWithValidate = $.extend({}, this.options, {validate: this.validate});
+    this.sandbox.spy(window, 'hoodieEvents');
     this.store = hoodieStoreApi(this.hoodie, this.options );
     this.storeWithCustomValidate = hoodieStoreApi(this.hoodie, this.optionsWithValidate );
   });
@@ -21,6 +22,10 @@ describe('hoodieStoreApi', function() {
 
   it('returns a function', function() {
     expect(this.store).to.be.a(Function);
+  });
+
+  it('adds event API', function() {
+    expect(window.hoodieEvents).to.be.calledWith(this.hoodie, { context : this.store, namespace: 'funkstore' });
   });
 
   describe('store("task", "id")', function() {
@@ -634,59 +639,6 @@ describe('hoodieStoreApi', function() {
       expect(this.options.backend.removeAll).to.be.calledWith('type', { option: 'value'});
     });
   }); // #removeAll
-
-  //
-  describe('#trigger', function() {
-    beforeEach(function() {
-      this.sandbox.spy(this.hoodie, 'trigger');
-    });
-
-    it('should proxy to hoodie.trigger with \'store\' namespace', function() {
-      this.store.trigger('event', {
-        funky: 'fresh'
-      });
-
-      expect(this.hoodie.trigger).to.be.calledWith('funkstore:event', {
-        funky: 'fresh'
-      });
-    });
-  }); // #trigger
-
-  //
-  describe('#on', function() {
-    beforeEach(function() {
-      this.sandbox.spy(this.hoodie, 'on');
-    });
-
-    it('should proxy to hoodie.on with \'store\' namespace', function() {
-      this.store.on('event', {
-        funky: 'fresh'
-      });
-      expect(this.hoodie.on).to.be.calledWith('funkstore:event', {
-        funky: 'fresh'
-      });
-    });
-
-    it('should namespace multiple events correctly', function() {
-      var cb = this.sandbox.spy();
-      this.store.on('super funky fresh', cb);
-      expect(this.hoodie.on.calledWith('funkstore:super funkstore:funky funkstore:fresh', cb)).to.be.ok();
-    });
-  }); // #on
-
-  //
-  describe('#unbind', function() {
-    beforeEach(function() {
-      this.sandbox.spy(this.hoodie, 'unbind');
-    });
-
-    it('should proxy to hoodie.unbind with \'store\' namespace', function() {
-      var cb = function() {};
-
-      this.store.unbind('event', cb);
-      expect(this.hoodie.unbind).to.be.calledWith('funkstore:event', cb);
-    });
-  }); // #unbind
 
   //
   describe('#decoratePromises', function() {


### PR DESCRIPTION
with the new implementation, we can dry out the core extensions. e.g. in store.js, instead of 

``` js
  // trigger
  // ---------

  // proxies to hoodie.trigger
  api.trigger = function trigger() {
    var eventName = arguments[0];
    var parameters = 2 <= arguments.length ? Array.prototype.slice.call(arguments, 1) : [];
    var prefix = storeName;

    return hoodie.trigger.apply(hoodie, [prefix + ':' + eventName].concat(Array.prototype.slice.call(parameters)));
  };


  // on
  // ---------

  // proxies to hoodie.on
  api.on = function on(eventName, data) {
    var prefix = storeName;

    eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');

    return hoodie.on(eventName, data);
  };


  // unbind
  // ---------

  // proxies to hoodie.unbind
  api.unbind = function unbind(eventName, callback) {
    var prefix = storeName;

    eventName = eventName.replace(/(^| )([^ ]+)/g, '$1'+prefix+':$2');
    return hoodie.unbind(eventName, callback);
  };
```

we now can do

``` js
hoodieEvents(hoodie, { context: api, namespace: storeName })
```
