### PR TITLE
V0.4 peanuts store sync events

### DIFF
--- a/src/hoodie/local_store.js
+++ b/src/hoodie/local_store.js
@@ -667,6 +667,7 @@ function hoodieStore (hoodie) {
 
     // remote events
     hoodie.on('remote:change', handleRemoteChange);
+    hoodie.on('remote:push', handlePushedObject);
   }
 
   // allow to run this once from outside
@@ -748,6 +749,14 @@ function hoodieStore (hoodie) {
         remote: true
       });
     }
+  }
+
+
+  //
+  // all local changes get bulk pushed. For each object with local
+  // changes that has been pushed we  trigger a sync event
+  function handlePushedObject(object) {
+    triggerEvents('sync', object);
   }
 
 
@@ -836,6 +845,12 @@ function hoodieStore (hoodie) {
 
     if (event !== 'new') {
       store.trigger('' + event + ':' + object.type + ':' + object.id, object, options);
+    }
+
+    // sync events have no changes, so we don't trigger
+    // "change" events.
+    if (event === 'sync') {
+      return
     }
 
     store.trigger('change', event, object, options);

--- a/src/hoodie/remote_store.js
+++ b/src/hoodie/remote_store.js
@@ -387,7 +387,9 @@ function hoodieRemoteStore (hoodie, options) {
     objectsForRemote = [];
 
     for (_i = 0, _len = objects.length; _i < _len; _i++) {
-      object = objects[_i];
+
+      // don't mess with original objects
+      object = $.extend(true, {}, objects[_i]);
       addRevisionTo(object);
       object = parseForRemote(object);
       objectsForRemote.push(object);
@@ -399,6 +401,11 @@ function hoodieRemoteStore (hoodie, options) {
       }
     });
 
+    pushRequest.done(function() {
+      for (var i = 0; i < objects.length; i++) {
+        remote.trigger('push', objects[i]);
+      }
+    });
     return pushRequest;
   };
 

--- a/test/specs/hoodie/local_store.spec.js
+++ b/test/specs/hoodie/local_store.spec.js
@@ -79,6 +79,19 @@ describe('hoodie.store', function() {
       this.clock.tick(2000);
       expect(this.store.trigger).to.be.calledWith('idle', 'changedObjects');
     });
+
+    it('should trigger "sync" events on objects that got pushed', function() {
+      this.store.subscribeToOutsideEvents();
+      this.hoodie.trigger('remote:push', { type: 'doc', id: 'funky' });
+      expect(this.store.trigger).to.be.calledWith('sync', { type: 'doc', id: 'funky' }, undefined);
+      expect(this.store.trigger).to.be.calledWith('sync:doc', { type: 'doc', id: 'funky' }, undefined);
+      expect(this.store.trigger).to.be.calledWith('sync:doc:funky', { type: 'doc', id: 'funky' }, undefined);
+
+      expect(this.store.trigger).to.not.be.calledWith('change', 'sync', { type: 'doc', id: 'funky' }, undefined);
+      expect(this.store.trigger).to.not.be.calledWith('change:doc', 'sync', { type: 'doc', id: 'funky' }, undefined);
+      expect(this.store.trigger).to.not.be.calledWith('change:doc:funky', 'sync', { type: 'doc', id: 'funky' }, undefined);
+    });
+
     _when('remote:change event gets fired', function() {
 
       beforeEach(function() {

--- a/test/specs/hoodie/remote_store.spec.js
+++ b/test/specs/hoodie/remote_store.spec.js
@@ -820,6 +820,18 @@ describe('hoodieRemoteStore', function() {
         var data = JSON.parse(this.hoodie.request.args[0][2].data);
         expect(data.docs.length).to.eql(3);
       });
+
+      _when('push request succeeds', function() {
+        beforeEach(function() {
+          this.requestDefer.resolve();
+        });
+
+        it('should trigger push events for each object', function() {
+          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '1' });
+          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '2' });
+          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '3' });
+        });
+      });
     }); // Array of docs passed
 
     _and('one deleted and one new doc passed', function() {


### PR DESCRIPTION
I've implemented a "sync" event for `hoodie.store.on`. It gets triggered on each object whose local changes have been pushed.

``` js
hoodie.store.on('sync', markObjectAsSynced )
hoodie.store.on('sync:document', function(doc) {} )
hoodie.store.on('sync:$message:123', callProgressCallbackOnTask )
```

@svnlto 
