### PR TITLE
V0.4 peanuts store update or add

### DIFF
--- a/src/hoodie/store.js
+++ b/src/hoodie/store.js
@@ -294,6 +294,23 @@ function hoodieStoreApi(hoodie, options) {
   };
 
 
+  // updateOrAdd
+  // -------------
+
+  // same as `.update()`, but in case the object cannot be found,
+  // it gets created
+  //
+  api.updateOrAdd = function updateOrAdd(type, id, objectUpdate, options) {
+    function handleNotFound() {
+      var properties = $.extend(true, {}, objectUpdate, {id: id});
+      return api.add(type, properties, options);
+    }
+
+    var promise = api.update(type, id, objectUpdate, options).then(null, handleNotFound);
+    return decoratePromise( promise );
+  };
+
+
   // updateAll
   // -----------------
 

--- a/src/hoodie/store.js
+++ b/src/hoodie/store.js
@@ -287,13 +287,9 @@ function hoodieStoreApi(hoodie, options) {
       return api.save(type, id, newObj, options);
     }
 
-    function handleNotFound() {
-      return api.save(type, id, objectUpdate, options);
-    }
-
     // promise decorations get lost when piped through `then`,
     // that's why we need to decorate the find's promise again.
-    var promise = api.find(type, id).then(handleFound, handleNotFound);
+    var promise = api.find(type, id).then(handleFound);
     return decoratePromise( promise );
   };
 

--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -411,6 +411,56 @@ describe('hoodieStoreApi', function() {
     }); // object can be found
   }); // #update
 
+  describe('#updateOrAdd(type, id, update, options)', function() {
+    beforeEach(function() {
+      this.updateDefer = this.hoodie.defer();
+      this.addDefer = this.hoodie.defer();
+      this.sandbox.stub(this.store, 'update').returns(this.updateDefer);
+      this.sandbox.stub(this.store, 'add').returns(this.addDefer);
+
+      this.promise = this.store.updateOrAdd('couch', '123', {
+        funky: 'fresh'
+      }, {option: 'value'});
+    });
+
+    it('updates object', function() {
+      expect(this.store.update).to.be.calledWith('couch', '123', {funky: 'fresh'}, {option: 'value'});
+    });
+
+    _when('object update succeeds', function() {
+      beforeEach(function() {
+        this.updateDefer.resolve('jup');
+      });
+
+      it('should resolve', function() {
+        expect(this.promise).to.be.resolvedWith('jup');
+      });
+    }); // object cannot be found
+
+    _when('object update fails', function() {
+      beforeEach(function() {
+        this.updateDefer.reject('nope');
+      });
+
+      it('should add the object to the store', function() {
+        expect(this.store.add).to.be.calledWith('couch', {
+          id: '123',
+          funky: 'fresh',
+        }, {option: 'value'});
+      });
+
+      it('rejects when adding object fails', function() {
+        this.addDefer.reject('nope');
+        expect(this.promise).to.be.rejectedWith('nope');
+      });
+
+      it('resolves when adding object succeeds', function() {
+        this.addDefer.resolve('yay');
+        expect(this.promise).to.be.resolvedWith('yay');
+      });
+    }); // object cannot be found
+  }); // #updateOrAdd
+
   describe('#updateAll(objects)', function() {
     beforeEach(function() {
       this.sandbox.stub(this.hoodie, 'isPromise').returns(false);

--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -268,16 +268,14 @@ describe('hoodieStoreApi', function() {
 
     _when('object cannot be found', function() {
       beforeEach(function() {
-        this.findDefer.reject();
+        this.findDefer.reject('not_found');
         this.promise = this.store.update('couch', '123', {
           funky: 'fresh'
         });
       });
 
-      it('should add it', function() {
-        expect(this.store.save).to.be.calledWith('couch', '123', {
-          funky: 'fresh'
-        }, undefined);
+      it('should reject', function() {
+        expect(this.promise).to.be.rejectedWith('not_found');
       });
     }); // object cannot be found
 


### PR DESCRIPTION
resolves #134

if object `doc/123` does not exist, this will now fail with a `not found` error:

``` js
hoodie.store.update('doc', '123', {title: 'funky!'});
```

To get the old behavior, use

``` js
hoodie.store.updateOrAdd('doc', '123', {title: 'funky!'});
```
