### PR TITLE
hoodie.remote.connect() should push local changes

### DIFF
--- a/src/hoodie/remote_store.js
+++ b/src/hoodie/remote_store.js
@@ -287,7 +287,7 @@ function hoodieRemoteStore (hoodie, options) {
     }
     remote.connected = true;
     remote.trigger('connect');
-    return remote.bootstrap();
+    return remote.bootstrap().then( this.push );
   };
 
 

--- a/src/hoodie/remote_store.js
+++ b/src/hoodie/remote_store.js
@@ -286,7 +286,7 @@ function hoodieRemoteStore (hoodie, options) {
       remoteName = name;
     }
     remote.connected = true;
-    remote.trigger('connect'); // TODO: spec that
+    remote.trigger('connect');
     return remote.bootstrap();
   };
 

--- a/src/hoodie/remote_store.js
+++ b/src/hoodie/remote_store.js
@@ -287,7 +287,7 @@ function hoodieRemoteStore (hoodie, options) {
     }
     remote.connected = true;
     remote.trigger('connect');
-    return remote.bootstrap().then( this.push );
+    return remote.bootstrap().then( function() { remote.push() } );
   };
 
 

--- a/test/specs/hoodie/remote_store.spec.js
+++ b/test/specs/hoodie/remote_store.spec.js
@@ -415,7 +415,7 @@ describe('hoodieRemoteStore', function() {
       expect(this.hoodie.request).to.be.calledWith('GET', '/funky%2Fstore/funk', { 'contentType': 'application/json' });
     });
 
-    it.only('pushes after bootstrap finished', function() {
+    it('pushes after bootstrap finished', function() {
       this.remote.connect();
       expect(this.remote.push).to.not.be.called();
       this.bootstrapDefer.resolve([1,2,3]);

--- a/test/specs/hoodie/remote_store.spec.js
+++ b/test/specs/hoodie/remote_store.spec.js
@@ -400,6 +400,11 @@ describe('hoodieRemoteStore', function() {
       expect(this.remote.bootstrap.called).to.be.ok();
     });
 
+    it('triggers `connect` event', function() {
+      this.remote.connect();
+      expect(this.remote.trigger).to.be.calledWith('connect');
+    });
+
     it('should set new name if passed as param', function() {
       this.remote.request('GET', '/funk');
       expect(this.hoodie.request).to.be.calledWith('GET', '/my%2Fstore/funk', { 'contentType': 'application/json' });

--- a/test/specs/hoodie/remote_store.spec.js
+++ b/test/specs/hoodie/remote_store.spec.js
@@ -386,7 +386,9 @@ describe('hoodieRemoteStore', function() {
 
   describe('#connect()', function() {
     beforeEach(function() {
-      this.sandbox.stub(this.remote, 'bootstrap');
+      this.bootstrapDefer = this.hoodie.defer();
+      this.sandbox.stub(this.remote, 'bootstrap').returns(this.bootstrapDefer);
+      this.sandbox.spy(this.remote, 'push');
     });
 
     it('should set connected to true', function() {
@@ -411,6 +413,13 @@ describe('hoodieRemoteStore', function() {
       this.remote.connect('funky/store');
       this.remote.request('GET', '/funk');
       expect(this.hoodie.request).to.be.calledWith('GET', '/funky%2Fstore/funk', { 'contentType': 'application/json' });
+    });
+
+    it('pushes after bootstrap finished', function() {
+      this.remote.connect();
+      expect(this.remote.push).to.not.be.called();
+      this.bootstrapDefer.resolve();
+      expect(this.remote.push).to.be.called();
     });
   }); // #connect
 

--- a/test/specs/hoodie/remote_store.spec.js
+++ b/test/specs/hoodie/remote_store.spec.js
@@ -415,11 +415,11 @@ describe('hoodieRemoteStore', function() {
       expect(this.hoodie.request).to.be.calledWith('GET', '/funky%2Fstore/funk', { 'contentType': 'application/json' });
     });
 
-    it('pushes after bootstrap finished', function() {
+    it.only('pushes after bootstrap finished', function() {
       this.remote.connect();
       expect(this.remote.push).to.not.be.called();
-      this.bootstrapDefer.resolve();
-      expect(this.remote.push).to.be.called();
+      this.bootstrapDefer.resolve([1,2,3]);
+      expect(this.remote.push).to.be.calledWith();
     });
   }); // #connect
 


### PR DESCRIPTION
With the current implementation, hoodie does not push local changes when an anonymous account gets created. In the particular case, when I try to send an email without having signed up, the email doesn't get send until I reload the page, because hoodie.connect gets called on `signin:anonymous`, but it doesn't push the local changes, only starts pulling.

I'm on it
