### PR TITLE
Memory store

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,10 @@ module.exports = function(grunt) {
           'src/hoodie/account.js',
           'src/hoodie/account_remote.js',
           'src/hoodie/task.js',
-          'src/hoodie/scoped_task.js'
+          'src/hoodie/scoped_task.js',
+
+          'src/hoodie/memory_store.js',
+          'src/hoodie/memory_open.js'
         ],
         dest: 'dist/<%= pkg.name %>.js'
       }

--- a/src/hoodie.js
+++ b/src/hoodie.js
@@ -100,6 +100,9 @@ function Hoodie(baseUrl) {
   // * hoodie.remote
   hoodie.extend( hoodieRemote );
 
+  // * hoodie.memory.open
+  hoodie.extend( hoodieMemoryOpen );
+
 
   //
   // Initializations

--- a/src/hoodie.js
+++ b/src/hoodie.js
@@ -48,7 +48,7 @@ function Hoodie(baseUrl) {
 
   /* global hoodieAccount, hoodieRemote, hoodieConfig, hoodieStore,
             hoodiePromises, hoodieRequest, hoodieConnection, hoodieUUID,
-            hoodieDispose, hoodieOpen, hoodieTask
+            hoodieDispose, hoodieOpen, hoodieTask, hoodieMemoryOpen
   */
 
   // * hoodie.bind

--- a/src/hoodie/memory_open.js
+++ b/src/hoodie/memory_open.js
@@ -1,4 +1,4 @@
-/* exported hoodieOpen */
+/* exported hoodieMemoryOpen */
 /* global hoodieMemoryStore */
 
 // Open stores

--- a/src/hoodie/memory_open.js
+++ b/src/hoodie/memory_open.js
@@ -1,0 +1,29 @@
+/* exported hoodieOpen */
+/* global hoodieMemoryStore */
+
+// Open stores
+// -------------
+
+function hoodieMemoryOpen(hoodie) {
+  var $extend = window.jQuery.extend;
+
+  // generic method to open an in memory store.
+  //
+  // hoodie.memory.open("some_store_name", {remote: remoteStore}).findAll()
+  //
+  function open(storeName, options) {
+    options = options || {};
+
+    $extend(options, {
+      name: storeName
+    });
+
+    return hoodieMemoryStore(hoodie, options);
+  }
+
+  //
+  // Public API
+  //
+  hoodie.memory = hoodie.memory || {};
+  hoodie.memory.open = open;
+}

--- a/src/hoodie/memory_store.js
+++ b/src/hoodie/memory_store.js
@@ -1,0 +1,761 @@
+/* exported hoodieStore */
+/* global hoodieStoreApi */
+
+// MemoryStore
+// ============
+//
+// Stores stuff in memory, optionally syncs to the passed remote store
+//
+
+function hoodieMemoryStore (hoodie, options) {
+  options = options || {};
+
+  var localStore = {};
+
+  //
+  // state
+  // -------
+  //
+
+  // the memory cache
+  var cachedObject = {};
+
+  // map of dirty objects by their ids
+  var dirty = {};
+
+  // queue of method calls done during bootstrapping
+  var queue = [];
+
+  // 2 seconds timout before triggering the `store:idle` event
+  //
+  var idleTimeout = 2000;
+
+
+
+
+  // ------
+  //
+  // saves the passed object into the store and replaces
+  // an eventually existing object with same type & id.
+  //
+  // When id is undefined, it gets generated an new object gets saved
+  //
+  // It also adds timestamps along the way:
+  //
+  // * `createdAt` unless it already exists
+  // * `updatedAt` every time
+  // * `_syncedAt`  if changes comes from remote
+  //
+  // example usage:
+  //
+  //     store.save('car', undefined, {color: 'red'})
+  //     store.save('car', 'abc4567', {color: 'red'})
+  //
+  localStore.save = function save(object, options) {
+    var currentObject, defer, error, event, isNew, key;
+
+    options = options || {};
+
+    // if store is currently bootstrapping data from remote,
+    // we're queueing local saves until it's finished.
+    if (store.isBootstrapping() && !options.remote) {
+      return enqueue('save', arguments);
+    }
+
+    // generate an id if necessary
+    if (object.id) {
+      currentObject = cache(object.type, object.id);
+      isNew = typeof currentObject !== 'object';
+    } else {
+      isNew = true;
+      object.id = hoodie.uuid();
+    }
+
+    if (isNew) {
+      // add createdBy hash
+      object.createdBy = object.createdBy || hoodie.account.ownerHash;
+    }
+    else {
+      // leave createdBy hash
+      if (currentObject.createdBy) {
+        object.createdBy = currentObject.createdBy;
+      }
+    }
+
+    // handle local properties and hidden properties with $ prefix
+    // keep local properties for remote updates
+    if (!isNew) {
+
+      // for remote updates, keep local properties (starting with '_')
+      // for local updates, keep hidden properties (starting with '$')
+      for (key in currentObject) {
+        if (!object.hasOwnProperty(key)) {
+          switch (key.charAt(0)) {
+          case '_':
+            if (options.remote) {
+              object[key] = currentObject[key];
+            }
+            break;
+          case '$':
+            if (!options.remote) {
+              object[key] = currentObject[key];
+            }
+          }
+        }
+      }
+    }
+
+    // add timestamps
+    if (options.remote) {
+      object._syncedAt = now();
+    } else if (!options.silent) {
+      object.updatedAt = now();
+      object.createdAt = object.createdAt || object.updatedAt;
+    }
+
+    // handle local changes
+    //
+    // A local change is meant to be replicated to the
+    // users database, but not beyond. For example when
+    // I subscribed to a share but then decide to unsubscribe,
+    // all objects get removed with local: true flag, so that
+    // they get removed from my database, but won't anywhere else.
+    if (options.local) {
+      object._$local = true;
+    } else {
+      delete object._$local;
+    }
+
+    defer = hoodie.defer();
+
+    try {
+      object = cache(object.type, object.id, object, options);
+      defer.resolve(object, isNew).promise();
+      event = isNew ? 'add' : 'update';
+      triggerEvents(event, object, options);
+    } catch (_error) {
+      error = _error;
+      defer.reject(error.toString());
+    }
+
+    return defer.promise();
+  };
+
+
+  // find
+  // ------
+
+  // loads one object from Store, specified by `type` and `id`
+  //
+  // example usage:
+  //
+  //     store.find('car', 'abc4567')
+  localStore.find = function(type, id) {
+    var defer, error, object;
+
+    defer = hoodie.defer();
+
+    // if store is currently bootstrapping data from remote,
+    // we're queueing until it's finished
+    if (store.isBootstrapping()) {
+      return enqueue('find', arguments);
+    }
+
+    try {
+      object = cache(type, id);
+      if (!object) {
+        defer.reject(Hoodie.Errors.NOT_FOUND(type, id)).promise();
+      }
+      defer.resolve(object);
+    } catch (_error) {
+      error = _error;
+      defer.reject(error);
+    }
+
+    return defer.promise();
+  };
+
+
+  // findAll
+  // ---------
+
+  // returns all objects from store.
+  // Can be optionally filtered by a type or a function
+  //
+  // example usage:
+  //
+  //     store.findAll()
+  //     store.findAll('car')
+  //     store.findAll(function(obj) { return obj.brand == 'Tesla' })
+  //
+  localStore.findAll = function findAll(filter) {
+    var currentType, defer, error, id, key, keys, obj, results, type;
+
+    if (filter == null) {
+      filter = function() {
+        return true;
+      };
+    }
+
+    // if store is currently bootstrapping data from remote,
+    // we're queueing until it's finished
+    if (store.isBootstrapping()) {
+      return enqueue('findAll', arguments);
+    }
+
+    keys = store.index();
+
+    // normalize filter
+    if (typeof filter === 'string') {
+      type = filter;
+      filter = function(obj) {
+        return obj.type === type;
+      };
+    }
+
+    defer = hoodie.defer();
+
+    try {
+
+      //
+      results = (function() {
+        var _i, _len, _ref, _results;
+        _results = [];
+        for (_i = 0, _len = keys.length; _i < _len; _i++) {
+          key = keys[_i];
+          if (!(isSemanticId(key))) {
+            continue;
+          }
+          _ref = key.split('/');
+          currentType = _ref[0];
+          id = _ref[1];
+
+          obj = cache(currentType, id);
+          if (obj && filter(obj)) {
+            _results.push(obj);
+          }
+        }
+        return _results;
+      }).call(this);
+
+      // sort from newest to oldest
+      results.sort(function(a, b) {
+        if (a.createdAt > b.createdAt) {
+          return -1;
+        } else if (a.createdAt < b.createdAt) {
+          return 1;
+        } else {
+          return 0;
+        }
+      });
+      defer.resolve(results).promise();
+    } catch (_error) {
+      error = _error;
+      defer.reject(error).promise();
+    }
+    return defer.promise();
+  };
+
+
+  // Remove
+  // --------
+
+  // Removes one object specified by `type` and `id`.
+  //
+  // when object has been synced before, mark it as deleted.
+  // Otherwise remove it from Store.
+  localStore.remove = function remove(type, id, options) {
+    var key, object, objectWasMarkedAsDeleted;
+
+    options = options || {};
+
+    // if store is currently bootstrapping data from remote,
+    // we're queueing local removes until it's finished.
+    if (store.isBootstrapping() && !options.remote) {
+      return enqueue('remove', arguments);
+    }
+
+    key = type + '/' + id;
+
+    object = cache(type, id);
+
+    // if change comes from remote, just clean up locally
+    if (options.remote) {
+      objectWasMarkedAsDeleted = cachedObject[key] && isMarkedAsDeleted(cachedObject[key]);
+      cachedObject[key] = false;
+      clearChanged(type, id);
+      if (objectWasMarkedAsDeleted && object) {
+        return hoodie.resolveWith(object);
+      }
+    }
+
+    if (!object) {
+      return hoodie.rejectWith(Hoodie.Errors.NOT_FOUND(type, id));
+    }
+
+    if (object._syncedAt) {
+      object._deleted = true;
+      cache(type, id, object);
+    } else {
+      key = type + '/' + id;
+      cachedObject[key] = false;
+      clearChanged(type, id);
+    }
+
+    // https://github.com/hoodiehq/hoodie.js/issues/147
+    if (options.update) {
+      object = options.update;
+      delete options.update;
+    }
+    triggerEvents('remove', object, options);
+    return hoodie.resolveWith(object);
+  };
+
+
+  // Remove all
+  // ----------
+
+  // Removes one object specified by `type` and `id`.
+  //
+  // when object has been synced before, mark it as deleted.
+  // Otherwise remove it from Store.
+  localStore.removeAll = function removeAll(type, options) {
+    return store.findAll(type).then(function(objects) {
+      var object, _i, _len, results;
+
+      results = [];
+
+      for (_i = 0, _len = objects.length; _i < _len; _i++) {
+        object = objects[_i];
+        results.push(store.remove(object.type, object.id, options));
+      }
+      return results;
+    });
+  };
+
+
+  // validate
+  // ----------
+
+  //
+  function validate (object) {
+
+    if (!isValidType(object.type)) {
+      return Hoodie.Errors.INVALID_KEY({
+        type: object.type
+      });
+    }
+
+    if (arguments.length > 0 && !isValidId(object.id)) {
+      return Hoodie.Errors.INVALID_KEY({
+        id: object.id
+      });
+    }
+  }
+
+  var store = hoodieStoreApi(hoodie, {
+
+    // validate
+    validate: validate,
+
+    backend: {
+      save: localStore.save,
+      find: localStore.find,
+      findAll: localStore.findAll,
+      remove: localStore.remove,
+      removeAll: localStore.removeAll
+    }
+  });
+
+
+
+  // extended public API
+  // ---------------------
+
+
+  // index
+  // -------
+
+  // object key index
+  // TODO: make this cachy
+  store.index = function index() {
+    var keys = [];
+    for (var key in cachedObject) {
+      if (cachedObject.hasOwnProperty(key) && isSemanticId(key)) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  };
+
+
+  // changed objects
+  // -----------------
+
+  // returns an Array of all dirty documents
+  store.changedObjects = function changedObjects() {
+    var id, key, object, type, _ref, _ref1, _results;
+
+    _ref = dirty;
+    _results = [];
+
+    for (key in _ref) {
+      if (_ref.hasOwnProperty(key)) {
+        object = _ref[key];
+        _ref1 = key.split('/');
+        type = _ref1[0];
+        id = _ref1[1];
+        object.type = type;
+        object.id = id;
+        _results.push(object);
+      }
+    }
+    return _results;
+  };
+
+
+  // Is dirty?
+  // ----------
+
+  // When no arguments passed, returns `true` or `false` depending on if there are
+  // dirty objects in the store.
+  //
+  // Otherwise it returns `true` or `false` for the passed object. An object is dirty
+  // if it has no `_syncedAt` attribute or if `updatedAt` is more recent than `_syncedAt`
+  store.hasLocalChanges = function(type, id) {
+    if (!type) {
+      return !$.isEmptyObject(dirty);
+    }
+    var key = [type,id].join('/');
+    if (dirty[key]) {
+      return true;
+    }
+    return hasLocalChanges(cache(type, id));
+  };
+
+
+  // Clear
+  // ------
+
+  // clears localStorage and cache
+  // TODO: do not clear entire localStorage, clear only the items that have been stored
+  //       using `hoodie.store` before.
+  store.clear = function clear() {
+    var defer = hoodie.defer();
+    try {
+      cachedObject = {};
+      clearChanged();
+      defer.resolve();
+      store.trigger('clear');
+    } catch (_error) {
+      defer.reject(_error);
+    }
+    return defer.promise();
+  };
+
+
+  // isBootstrapping
+  // -----------------
+
+  // returns true if store is currently bootstrapping data from remote,
+  // otherwise false.
+  var bootstrapping = false;
+  store.isBootstrapping = function isBootstrapping() {
+    return bootstrapping;
+  };
+
+
+
+
+  //
+  // Private methods
+  // -----------------
+  //
+
+
+  // Cache
+  // -------
+
+  // loads an object specified by `type` and `id`
+  // and caches it for faster future access. Updates cache when `value` is passed.
+  //
+  // Also checks if object needs to be synched (dirty) or not
+  //
+  // Pass `options.remote = true` when object comes from remote
+  // Pass 'options.silent = true' to avoid events from being triggered.
+  function cache(type, id, object, options) {
+    var key;
+
+    if (object === undefined) {
+      object = false;
+    }
+
+    options = options || {};
+    key = '' + type + '/' + id;
+
+    if (object) {
+      $.extend(object, {
+        type: type,
+        id: id
+      });
+
+      if (options.remote) {
+        clearChanged(type, id);
+        cachedObject[key] = $.extend(true, {}, object);
+        return cachedObject[key];
+      }
+
+    } else {
+
+      // if the cached key returns false, it means
+      // that we have removed that key. We just
+      // set it to false for performance reasons, so
+      // that we don't need to look it up again in localStorage
+      if (cachedObject[key] === false) {
+        return false;
+      }
+
+      // if key is cached, return it. But make sure
+      // to make a deep copy beforehand (=> true)
+      if (cachedObject[key]) {
+        return $.extend(true, {}, cachedObject[key]);
+      }
+
+      // stop here if object did not exist
+      // and cache it so we don't need to look it up again
+      if (object === false) {
+        clearChanged(type, id);
+        cachedObject[key] = false;
+        return false;
+      }
+
+    }
+
+    if (isMarkedAsDeleted(object)) {
+      markAsChanged(type, id, object, options);
+      cachedObject[key] = false;
+      return false;
+    }
+
+    // here is where we cache the object for
+    // future quick access
+    cachedObject[key] = $.extend(true, {}, object);
+
+    if (hasLocalChanges(object)) {
+      markAsChanged(type, id, cachedObject[key], options);
+    } else {
+      clearChanged(type, id);
+    }
+
+    return $.extend(true, {}, object);
+  }
+
+
+  //
+  // subscribe to events coming from our remote store.
+  //
+  function subscribeToOutsideEvents() {
+    if (!options.remote) {
+      return;
+    }
+
+    options.remote.on('bootstrap:start', startBootstrappingMode);
+    options.remote.on('bootstrap:end', endBootstrappingMode);
+    options.remote.on('change', handleRemoteChange);
+    options.remote.on('push', handlePushedObject);
+
+    options.remote.on('connect', function() {
+      store.on('idle', options.remote.push);
+      remote.push();
+    });
+
+    options.remote.on('disconnect', function() {
+      store.unbind('idle', options.remote.push);
+    });
+
+    hoodie.on('disconnected', options.remote.disconnect);
+    hoodie.on('reconnected', options.remote.connect);
+  }
+
+  // allow to run this once from outside
+  store.subscribeToOutsideEvents = function() {
+    subscribeToOutsideEvents();
+    delete store.subscribeToOutsideEvents;
+  };
+
+
+  //
+  // Marks object as changed (dirty). Triggers a `store:dirty` event immediately and a
+  // `store:idle` event once there is no change within 2 seconds
+  //
+  function markAsChanged(type, id, object, options) {
+    var key;
+
+    options = options || {};
+    key = '' + type + '/' + id;
+
+    dirty[key] = object;
+
+    if (options.silent) {
+      return;
+    }
+
+    triggerDirtyAndIdleEvents();
+  }
+
+  // Clear changed
+  // ---------------
+
+  // removes an object from the list of objects that are flagged to by synched (dirty)
+  // and triggers a `store:dirty` event
+  function clearChanged(type, id) {
+    if (type && id) {
+      delete dirty['' + type + '/' + id];
+    } else {
+      dirty = {};
+    }
+    return window.clearTimeout(dirtyTimeout);
+  }
+
+
+  // when a change come's from our remote store, we differentiate
+  // whether an object has been removed or added / updated and
+  // reflect the change in our local store.
+  function handleRemoteChange(typeOfChange, object) {
+    if (typeOfChange === 'remove') {
+      store.remove(object.type, object.id, {
+        remote: true,
+        update: object
+      });
+    } else {
+      store.save(object.type, object.id, object, {
+        remote: true
+      });
+    }
+  }
+
+
+  //
+  // all local changes get bulk pushed. For each object with local
+  // changes that has been pushed we  trigger a sync event
+  function handlePushedObject(object) {
+    triggerEvents('sync', object);
+  }
+
+  //
+  function now() {
+    return JSON.stringify(new Date()).replace(/['"]/g, '');
+  }
+
+  // only lowercase letters, numbers and dashes are allowed for ids
+  var validIdPattern = /^[a-z0-9\-]+$/;
+  function isValidId(id) {
+    return validIdPattern.test(id);
+  }
+
+  // just like ids, but must start with a letter or a $ (internal types)
+  var validTypePattern = /^[a-z$][a-z0-9]+$/;
+  function isValidType(type) {
+    return validTypePattern.test(type);
+  }
+
+  //
+  var semanticIdPattern = /^[a-z$][a-z0-9]+\/[a-z0-9]+$/;
+  function isSemanticId(key) {
+    return semanticIdPattern.test(key);
+  }
+
+  // `hasLocalChanges` returns true if there is a local change that
+  // has not been sync'd yet.
+  function hasLocalChanges(object) {
+    if (!object.updatedAt) {
+      return false;
+    }
+    if (!object._syncedAt) {
+      return true;
+    }
+    return object._syncedAt < object.updatedAt;
+  }
+
+  //
+  function isMarkedAsDeleted(object) {
+    return object._deleted === true;
+  }
+
+  // this is where all the store events get triggered,
+  // like add:task, change:note:abc4567, remove, etc.
+  function triggerEvents(eventName, object, options) {
+    store.trigger(eventName, $.extend(true, {}, object), options);
+    store.trigger(object.type + ':' + eventName, $.extend(true, {}, object), options);
+
+    if (eventName !== 'new') {
+      store.trigger( object.type + ':' + object.id+ ':' + eventName, $.extend(true, {}, object), options);
+    }
+
+    // sync events have no changes, so we don't trigger
+    // "change" events.
+    if (eventName === 'sync') {
+      return;
+    }
+
+    store.trigger('change', eventName, $.extend(true, {}, object), options);
+    store.trigger(object.type + ':change', eventName, $.extend(true, {}, object), options);
+
+    if (eventName !== 'new') {
+      store.trigger(object.type + ':' + object.id + ':change', eventName, $.extend(true, {}, object), options);
+    }
+  }
+
+  // when an object gets changed, two special events get triggerd:
+  //
+  // 1. dirty event
+  //    the `dirty` event gets triggered immediately, for every
+  //    change that happens.
+  // 2. idle event
+  //    the `idle` event gets triggered after a short timeout of
+  //    no changes, e.g. 2 seconds.
+  var dirtyTimeout;
+  function triggerDirtyAndIdleEvents() {
+    store.trigger('dirty');
+    window.clearTimeout(dirtyTimeout);
+
+    dirtyTimeout = window.setTimeout(function() {
+      store.trigger('idle', store.changedObjects());
+    }, idleTimeout);
+  }
+
+  //
+  function startBootstrappingMode() {
+    bootstrapping = true;
+    store.trigger('bootstrap:start');
+  }
+
+  //
+  function endBootstrappingMode() {
+    var methodCall, method, args, defer;
+
+    bootstrapping = false;
+    while(queue.length > 0) {
+      methodCall = queue.shift();
+      method = methodCall[0];
+      args = methodCall[1];
+      defer = methodCall[2];
+      localStore[method].apply(localStore, args).then(defer.resolve, defer.reject);
+    }
+
+    store.trigger('bootstrap:end');
+  }
+
+  //
+  function enqueue(method, args) {
+    var defer = hoodie.defer();
+    queue.push([method, args, defer]);
+    return defer.promise();
+  }
+
+  //
+  // expose public API
+  //
+  // inherit from Hoodies Store API
+  return store;
+}

--- a/src/hoodie/memory_store.js
+++ b/src/hoodie/memory_store.js
@@ -1,4 +1,4 @@
-/* exported hoodieStore */
+/* exported hoodieMemoryStore */
 /* global hoodieStoreApi */
 
 // MemoryStore
@@ -566,7 +566,7 @@ function hoodieMemoryStore (hoodie, options) {
 
     options.remote.on('connect', function() {
       store.on('idle', options.remote.push);
-      remote.push();
+      options.remote.push();
     });
 
     options.remote.on('disconnect', function() {

--- a/src/hoodie/memory_store.js
+++ b/src/hoodie/memory_store.js
@@ -26,9 +26,8 @@ function hoodieMemoryStore (hoodie, options) {
   // queue of method calls done during bootstrapping
   var queue = [];
 
-  // 2 seconds timout before triggering the `store:idle` event
-  //
-  var idleTimeout = 2000;
+  // 2 seconds timout before triggering the `idle` event
+  var idleTimeout = options.idleTimeout === undefined ? 2000 : options.idleTimeout;
 
 
 


### PR DESCRIPTION
More to open the discussion than anything else.

I needed an in memory store for the [hoodie blackboard](https://github.com/alanshaw/hoodie-blackboard). It's using [punk](https://npmjs.org/package/hoodie-plugin-punk) and [reactive](https://npmjs.org/package/hoodie-plugin-reactive).
- Punk is just a remote store that anyone can write to
- Reactive uses store `change` events to run and re-run computations. In this case when a line is inserted into the database, the canvas is wiped and all the lines redrawn.

Relying on `change` events from the punk remote is too latent when drawing - I need stuff to appear straight away, and get sync'd in the background. `local_store.js` is tied to localStorage and only visible to the current user, not everyone so no good if you want to draw together.

I'm using all these things here (should be reasonably self explanatory):
https://github.com/alanshaw/hoodie-blackboard/blob/master/www/js/main.js#L7-L10

`memory_store.js` is essentially `local_store.js` without the localStorage bits. I guess it could be done better. If you pass it a `remote` option it'll sync with that remote store, after you call `subscribeToOutsideEvents`. In the blackboard example I'm creating a in memory store called "punk" with syncs with the `hoodie.punk` remote.

`memory_open.js` is similar to `open.js` but it opens a memory store and attaches itself to `hoodie.memory.open`.

So really, if this gets merged I'd be looking to have punk create its own memory store, but I thought it would be beneficial for other plugin authors to do the same or for app developers to create memory stores that don't get sync'd to a remote.
