### PR TITLE
hoodie.account.resetPasswords(email) resolves although email could not be found.

### DIFF
--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -498,7 +498,7 @@ function hoodieAccount (hoodie) {
           window.setTimeout(account.checkPasswordReset, 1000);
           return;
         }
-        return account.trigger('passwordreset:error');
+        return account.trigger('error:passwordreset', error);
       });
     });
   };

--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -794,14 +794,14 @@ function hoodieAccount (hoodie) {
   // If the error is a 401, it's exactly what we've been waiting for.
   // In this case we resolve the promise.
   //
-  function handlePasswordResetStatusRequestError(xhr) {
-    if (xhr.status === 401) {
+  function handlePasswordResetStatusRequestError(error) {
+    if (error.error === 'unauthorized') {
       hoodie.config.unset('_account.resetPasswordId');
       account.trigger('passwordreset');
 
       return hoodie.resolve();
     } else {
-      return handleRequestError(xhr);
+      return hoodie.rejectWith(error);
     }
   }
 

--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -498,7 +498,7 @@ function hoodieAccount (hoodie) {
           window.setTimeout(account.checkPasswordReset, 1000);
           return;
         }
-        return account.trigger('password_reset:error');
+        return account.trigger('passwordreset:error');
       });
     });
   };

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -1767,8 +1767,30 @@ describe('hoodie.account', function () {
           expect(this.account.checkPasswordReset.called).to.be.ok();
         });
 
-        it('should be resolved', function () {
-          expect(this.account.resetPassword('joe@example.com')).to.be.resolved();
+        it('should be pending', function () {
+          expect(this.account.resetPassword('joe@example.com')).to.be.pending();
+        });
+
+        _and('password reset succeeds', function() {
+          beforeEach(function() {
+            this.promise = this.account.resetPassword('joe@example.com');
+            this.account.one.witArgs('passwordreset').yields();
+          });
+
+          it.only('shoudl resolve', function() {
+            expect(this.promise).to.be.resolved();
+          });
+        });
+
+        _and('password reset fails', function() {
+          beforeEach(function() {
+            this.promise = this.account.resetPassword('joe@example.com');
+            this.account.one.witArgs('error:passwordreset').yields();
+          });
+
+          it('shoudl resolve', function() {
+            expect(this.promise).to.be.rejected();
+          });
         });
       });
 

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -1777,7 +1777,7 @@ describe('hoodie.account', function () {
             this.account.one.witArgs('passwordreset').yields();
           });
 
-          it.only('shoudl resolve', function() {
+          it.only('should resolve', function() {
             expect(this.promise).to.be.resolved();
           });
         });
@@ -1788,7 +1788,7 @@ describe('hoodie.account', function () {
             this.account.one.witArgs('error:passwordreset').yields();
           });
 
-          it('shoudl resolve', function() {
+          it('should resolve', function() {
             expect(this.promise).to.be.rejected();
           });
         });

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -1773,19 +1773,19 @@ describe('hoodie.account', function () {
 
         _and('password reset succeeds', function() {
           beforeEach(function() {
-            this.promise = this.account.resetPassword('joe@example.com');
             this.account.one.withArgs('passwordreset').yields();
+            this.promise = this.account.resetPassword('joe@example.com');
           });
 
-          it.only('should resolve', function() {
+          it('should resolve', function() {
             expect(this.promise).to.be.resolved();
           });
         });
 
         _and('password reset fails', function() {
           beforeEach(function() {
-            this.promise = this.account.resetPassword('joe@example.com');
             this.account.one.withArgs('error:passwordreset').yields();
+            this.promise = this.account.resetPassword('joe@example.com');
           });
 
           it('should resolve', function() {

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -1774,7 +1774,7 @@ describe('hoodie.account', function () {
         _and('password reset succeeds', function() {
           beforeEach(function() {
             this.promise = this.account.resetPassword('joe@example.com');
-            this.account.one.witArgs('passwordreset').yields();
+            this.account.one.withArgs('passwordreset').yields();
           });
 
           it.only('should resolve', function() {
@@ -1785,7 +1785,7 @@ describe('hoodie.account', function () {
         _and('password reset fails', function() {
           beforeEach(function() {
             this.promise = this.account.resetPassword('joe@example.com');
-            this.account.one.witArgs('error:passwordreset').yields();
+            this.account.one.withArgs('error:passwordreset').yields();
           });
 
           it('should resolve', function() {


### PR DESCRIPTION
the feature works as expected, the worker does its job. But it returns an error:

``` json
{
    "_id": "org.couchdb.user:$passwordReset/joe@example.com/lr8onx3",
    "_rev": "2-e58c496dc293dc39c89bd39a0505141a",
    "type": "user",
    "roles": [],
    "password_scheme": "pbkdf2",
    "iterations": 10,
    "name": "$passwordReset/joe@example.com/lr8onx3",
    "createdAt": "2013-11-08T15:53:39.863Z",
    "updatedAt": "2013-11-08T15:53:39.709Z",
    "derived_key": "72d8c1bcf98c6ece9789e823bfdbb5fee6d31e68",
    "salt": "559642e536109adfafbe5410152c5473",
    "$error": {
        "error": "not_found",
        "message": "user joe@example.com could not be found"
    }
}
```

Nevertheless, hoodie.account.resetPasswords() resolved. Expected behaviour would be to reject with `$error`
