### PR TITLE
force hoodie to reauthenticate when hoodie.remote triggered an unauthenticated error

### DIFF
--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -538,8 +538,28 @@ function hoodieAccount (hoodie) {
   };
 
 
+  //
+  // subscribe to events coming outside
+  //
+  function subscribeToOutsideEvents() {
+    hoodie.on('remote:error:unauthenticated', reauthenticate);
+  }
+
+  // allow to run this once from outside
+  account.subscribeToOutsideEvents = function() {
+    subscribeToOutsideEvents();
+    delete account.subscribeToOutsideEvents;
+  };
+
+
   // PRIVATE
   // ---------
+
+  // reauthenticate: force hoodie to reauthenticate
+  function reauthenticate () {
+    authenticated = undefined;
+    return account.authenticate();
+  }
 
   // setters
   function setUsername(newUsername) {

--- a/src/hoodie/account_remote.js
+++ b/src/hoodie/account_remote.js
@@ -101,7 +101,7 @@ function hoodieRemote (hoodie) {
   }
 
   //
-  // subscribe to events coming from account
+  // subscribe to events coming from outside
   //
   function subscribeToOutsideEvents() {
 

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -1976,8 +1976,33 @@ describe('hoodie.account', function () {
         expect(this.promise).to.be.rejected();
       });
     }); // signIn fails
-  });
+  }); // #changeUsername
 
+
+  describe('#subscribeToOutsideEvents', function() {
+    beforeEach(function() {
+      var events = {};
+
+      this.sandbox.stub(this.hoodie, 'on', function(eventName, cb) {
+        events[eventName] = cb;
+      });
+      this.sandbox.spy(this.account, 'request');
+      this.sandbox.stub(this.account, 'hasAccount').returns(true);
+      this.account.subscribeToOutsideEvents();
+      this.hoodie.on.reset();
+      this.events = events;
+    });
+
+    it('subscribes to remote:error:unauthenticated', function() {
+      expect(this.events['remote:error:unauthenticated']).to.be.a(Function);
+    });
+
+    it('reauthenticateds on remote:error:unauthenticated', function() {
+      this.hoodie.request.reset();
+      this.events['remote:error:unauthenticated']();
+      expect(this.account.request).to.be.calledWith('GET', '/_session');
+    });
+  });
 });
 
 function validSessionResponse () {


### PR DESCRIPTION
right now, when changes get pulled or pushed, but the server responses with 401 unauthenticated, the `unauthenticated` error does not get triggered. That's fixed with this pull request.
