### PR TITLE
remove artificial timeout before local changes get pushed

### DIFF
--- a/src/hoodie/account_remote.js
+++ b/src/hoodie/account_remote.js
@@ -106,12 +106,12 @@ function hoodieRemote (hoodie) {
   function subscribeToOutsideEvents() {
 
     hoodie.on('remote:connect', function() {
-      hoodie.on('store:idle', remote.push);
+      hoodie.on('store:dirty', remote.push);
       remote.push();
     });
 
     hoodie.on('remote:disconnect', function() {
-      hoodie.unbind('store:idle', remote.push);
+      hoodie.unbind('store:dirty', remote.push);
     });
 
     hoodie.on('disconnected', remote.disconnect);

--- a/src/hoodie/local_store.js
+++ b/src/hoodie/local_store.js
@@ -25,10 +25,6 @@ function hoodieStore (hoodie) {
   // queue of method calls done during bootstrapping
   var queue = [];
 
-  // 2 seconds timout before triggering the `store:idle` event
-  //
-  var idleTimeout = 2000;
-
 
 
 
@@ -683,8 +679,7 @@ function hoodieStore (hoodie) {
 
 
   //
-  // Marks object as changed (dirty). Triggers a `store:dirty` event immediately and a
-  // `store:idle` event once there is no change within 2 seconds
+  // Marks object as changed (dirty). Triggers a `store:dirty` event
   //
   function markAsChanged(type, id, object, options) {
     var key;
@@ -699,7 +694,7 @@ function hoodieStore (hoodie) {
       return;
     }
 
-    triggerDirtyAndIdleEvents();
+    store.trigger('dirty');
   }
 
   // Clear changed
@@ -716,7 +711,6 @@ function hoodieStore (hoodie) {
       dirty = {};
     }
     saveDirtyIds();
-    return window.clearTimeout(dirtyTimeout);
   }
 
 
@@ -736,7 +730,7 @@ function hoodieStore (hoodie) {
       }
 
       saveDirtyIds();
-      triggerDirtyAndIdleEvents();
+      store.trigger('dirty');
     });
   }
 
@@ -887,24 +881,6 @@ function hoodieStore (hoodie) {
       // https://github.com/hoodiehq/hoodie.js/issues/146
       store.trigger('change:' + object.type + ':' + object.id, eventName, $.extend(true, {}, object), options);
     }
-  }
-
-  // when an object gets changed, two special events get triggerd:
-  //
-  // 1. dirty event
-  //    the `dirty` event gets triggered immediately, for every
-  //    change that happens.
-  // 2. idle event
-  //    the `idle` event gets triggered after a short timeout of
-  //    no changes, e.g. 2 seconds.
-  var dirtyTimeout;
-  function triggerDirtyAndIdleEvents() {
-    store.trigger('dirty');
-    window.clearTimeout(dirtyTimeout);
-
-    dirtyTimeout = window.setTimeout(function() {
-      store.trigger('idle', store.changedObjects());
-    }, idleTimeout);
   }
 
   //

--- a/test/specs/hoodie/account_remote.spec.js
+++ b/test/specs/hoodie/account_remote.spec.js
@@ -106,17 +106,17 @@ describe('hoodie.remote', function() {
       this.events['remote:connect']();
       expect(this.remote.push).to.be.called();
     });
-    it('subscribes to store:idle on remote:connect', function() {
+    it('subscribes to store:dirty on remote:connect', function() {
       this.events['remote:connect']();
-      expect(this.hoodie.on).to.be.calledWith('store:idle', this.remote.push);
+      expect(this.hoodie.on).to.be.calledWith('store:dirty', this.remote.push);
     });
 
     it('subscribes to remote:disconnect', function() {
       expect(this.events['remote:disconnect']).to.be.a(Function);
     });
-    it('unbinds from store:idle on remote:disconnect', function() {
+    it('unbinds from store:dirty on remote:disconnect', function() {
       this.events['remote:disconnect']();
-      expect(this.hoodie.unbind).to.be.calledWith('store:idle', this.remote.push);
+      expect(this.hoodie.unbind).to.be.calledWith('store:dirty', this.remote.push);
     });
 
     it('subscribes to reconnected', function() {

--- a/test/specs/hoodie/local_store.spec.js
+++ b/test/specs/hoodie/local_store.spec.js
@@ -76,8 +76,6 @@ describe('hoodie.store', function() {
       this.hoodie.trigger('account:signup');
       expect(localStorage.setItem).to.be.calledWith('_dirty', 'doc/funky,doc/fresh');
       expect(this.store.trigger).to.be.calledWith('dirty');
-      this.clock.tick(2000);
-      expect(this.store.trigger).to.be.calledWith('idle', 'changedObjects');
     });
 
     it('should trigger "sync" events on objects that got pushed', function() {


### PR DESCRIPTION
The reason why this is in is that I wanted to let people save objects on any keyboard press, just like minutes.io is doing it. But truth is, this does not belong into hoodie core, cause by far not all apps are made this way.
