### PR TITLE
remove hoodie.generateId() from public API

### DIFF
--- a/src/hoodie.js
+++ b/src/hoodie.js
@@ -17,7 +17,6 @@ var hoodieOpen = require('./hoodie/open');
 var hoodieEvents = require('./lib/events');
 
 var hoodieRequest = require('./utils/request');
-var hoodieGenerateId = require('./utils/generate_id');
 var hoodiePromises = require('./utils/promises');
 
 // Constructor
@@ -83,9 +82,6 @@ function Hoodie(baseUrl) {
   // * hoodie.isOnline
   // * hoodie.checkConnection
   hoodie.extend(hoodieConnection);
-
-  // * hoodie.uuid
-  hoodie.extend(hoodieGenerateId);
 
   // * hoodie.dispose
   hoodie.extend(hoodieDispose);

--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -3,6 +3,7 @@
 
 var hoodieEvents = require('../lib/events');
 var extend = require('extend');
+var generateId = require('../utils/generate_id');
 
 //
 function hoodieAccount(hoodie) {
@@ -175,7 +176,7 @@ function hoodieAccount(hoodie) {
   account.anonymousSignUp = function anonymousSignUp() {
     var password, username;
 
-    password = hoodie.generateId(10);
+    password = generateId(10);
     username = hoodie.id();
 
     return account.signUp(username, password).done(function() {
@@ -410,7 +411,7 @@ function hoodieAccount(hoodie) {
       return account.checkPasswordReset();
     }
 
-    resetPasswordId = '' + username + '/' + (hoodie.generateId());
+    resetPasswordId = '' + username + '/' + (generateId());
 
     hoodie.config.set('_account.resetPasswordId', resetPasswordId);
 

--- a/src/hoodie/id.js
+++ b/src/hoodie/id.js
@@ -1,6 +1,8 @@
 // hoodie.id
 // =========
 
+var generateId = require('../utils/generate_id');
+
 // generates a random id and persists using hoodie.config
 // until the user signs out or deletes local data
 function hoodieId (hoodie) {
@@ -8,7 +10,7 @@ function hoodieId (hoodie) {
 
   function getId() {
     if (! id) {
-      setId( hoodie.generateId() );
+      setId( generateId() );
     }
     return id;
   }

--- a/src/hoodie/store.js
+++ b/src/hoodie/store.js
@@ -5,6 +5,7 @@
 var hoodieStoreApi = require('../lib/store/api');
 var HoodieObjectTypeError = require('../lib/error/object_type');
 var HoodieObjectIdError = require('../lib/error/object_id');
+var generateId = require('../utils/generate_id');
 
 var extend = require('extend');
 
@@ -69,7 +70,7 @@ function hoodieStore (hoodie) {
       isNew = typeof currentObject !== 'object';
     } else {
       isNew = true;
-      object.id = hoodie.generateId();
+      object.id = generateId();
     }
 
     if (isNew) {

--- a/src/lib/store/remote.js
+++ b/src/lib/store/remote.js
@@ -38,6 +38,7 @@
 
 var hoodieStoreApi = require('./api');
 var extend = require('extend');
+var generateId = require('../../utils/generate_id');
 
 //
 function hoodieRemoteStore(hoodie, options) {
@@ -118,7 +119,7 @@ function hoodieRemoteStore(hoodie, options) {
     var path;
 
     if (!object.id) {
-      object.id = hoodie.generateId();
+      object.id = generateId();
     }
 
     object = parseForRemote(object);
@@ -585,7 +586,7 @@ function hoodieRemoteStore(hoodie, options) {
 
   //
   function generateNewRevisionId() {
-    return hoodie.generateId(9);
+    return generateId(9);
   }
 
 

--- a/src/utils/generate_id.js
+++ b/src/utils/generate_id.js
@@ -1,39 +1,28 @@
-// hoodie.generateId
-// =============
+var chars, i, radix;
+
+// uuids consist of numbers and lowercase letters only.
+// We stick to lowercase letters to prevent confusion
+// and to prevent issues with CouchDB, e.g. database
+// names do wonly allow for lowercase letters.
+chars = '0123456789abcdefghijklmnopqrstuvwxyz'.split('');
+radix = chars.length;
 
 // helper to generate unique ids.
-function hoodieGenerateId (hoodie) {
-  var chars, i, radix;
+function generateId (length) {
+  var id = '';
 
-  // uuids consist of numbers and lowercase letters only.
-  // We stick to lowercase letters to prevent confusion
-  // and to prevent issues with CouchDB, e.g. database
-  // names do wonly allow for lowercase letters.
-  chars = '0123456789abcdefghijklmnopqrstuvwxyz'.split('');
-  radix = chars.length;
-
-
-  function generateId(length) {
-    var id = '';
-
-    // default uuid length to 7
-    if (length === undefined) {
-      length = 7;
-    }
-
-    for (i = 0; i < length; i++) {
-      var rand = Math.random() * radix;
-      var char = chars[Math.floor(rand)];
-      id += String(char).charAt(0);
-    }
-
-    return id;
+  // default uuid length to 7
+  if (length === undefined) {
+    length = 7;
   }
 
-  //
-  // Public API
-  //
-  hoodie.generateId = generateId;
+  for (i = 0; i < length; i++) {
+    var rand = Math.random() * radix;
+    var char = chars[Math.floor(rand)];
+    id += String(char).charAt(0);
+  }
+
+  return id;
 }
 
-module.exports = hoodieGenerateId;
+module.exports = generateId;

--- a/test/mocks/generate_id.js
+++ b/test/mocks/generate_id.js
@@ -1,4 +1,0 @@
-// hoodieGenerateId
-module.exports = function() {
-  return this.sandbox.stub().returns('uuid123');
-};

--- a/test/mocks/hoodie.js
+++ b/test/mocks/hoodie.js
@@ -1,7 +1,6 @@
 // modules
 var account = require('./account');
 var config = require('./config');
-var generateId = require('./generate_id');
 var localStore = require('./local_store');
 var openMethod = require('./open');
 var accountRemote = require('./account_remote');
@@ -24,7 +23,6 @@ module.exports = function () {
     // helpers
     request: request.apply(this),
     open: openMethod.apply(this),
-    generateId: generateId.apply(this),
     id: id.apply(this),
 
     // main modules

--- a/test/mocks/index.js
+++ b/test/mocks/index.js
@@ -4,7 +4,6 @@ module.exports = {
   connection: require('./connection'),
   dispose: require('./dispose'),
   events: require('./events'),
-  generate_id: require('./generate_id'),
   hoodie: require('./hoodie'),
   id: require('./id'),
   localStore: require('./local_store'),

--- a/test/mocks/utils/generate_id.js
+++ b/test/mocks/utils/generate_id.js
@@ -1,0 +1,2 @@
+// generateId
+module.exports = sinon.stub().returns('uuid123');

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -1,5 +1,8 @@
 require('../../lib/setup');
 
+var generateIdMock = require('../../mocks/utils/generate_id');
+global.stubRequire('src/utils/generate_id', generateIdMock);
+
 var hoodieAccount = require('../../../src/hoodie/account');
 var extend = require('extend');
 
@@ -11,6 +14,7 @@ describe('hoodie.account', function() {
     this.noop = function() {};
 
     this.hoodie = this.MOCKS.hoodie.apply(this);
+    generateIdMock.returns('uuid123');
 
     // for more sophisticated request stubbing
     this.requestDefers = [];
@@ -819,7 +823,7 @@ describe('hoodie.account', function() {
 
       it('should generate a password and store it locally in _account.anonymousPassword', function() {
         this.account.anonymousSignUp();
-        expect(this.hoodie.generateId).to.be.calledWith(10);
+        expect(generateIdMock).to.be.calledWith(10);
         expect(this.hoodie.config.set).to.be.calledWith('_account.anonymousPassword', 'uuid123');
       });
     });
@@ -1716,7 +1720,7 @@ describe('hoodie.account', function() {
         this.hoodie.config.get.resetBehavior();
 
         this.hoodie.config.get.returns(void 0);
-        this.hoodie.generateId.returns('uuid567');
+        generateIdMock.returns('uuid567');
 
         this.account.resetPassword('joe@example.com');
 

--- a/test/specs/hoodie/id.spec.js
+++ b/test/specs/hoodie/id.spec.js
@@ -1,4 +1,7 @@
 require('../../lib/setup');
+
+var generateIdMock = require('../../mocks/utils/generate_id');
+global.stubRequire('src/utils/generate_id', generateIdMock);
 var hoodieId = require('../../../src/hoodie/id');
 
 describe('hoodie.id()', function() {
@@ -7,7 +10,7 @@ describe('hoodie.id()', function() {
     this.hoodie = this.MOCKS.hoodie.apply(this);
     hoodieId(this.hoodie);
     this.id = this.hoodie.id;
-    this.hoodie.generateId.returns('randomid');
+    generateIdMock.returns('randomid');
   });
   it('returns a random id when called the first time', function() {
     var id = this.id();
@@ -15,10 +18,10 @@ describe('hoodie.id()', function() {
   });
 
   it('generates a new id only once', function() {
-    this.hoodie.generateId.reset();
+    generateIdMock.reset();
     var id1 = this.id();
     var id2 = this.id();
-    expect(this.hoodie.generateId.calledOnce).to.be.ok();
+    expect(generateIdMock.calledOnce).to.be.ok();
     expect(id1).to.eql(id2);
   });
 
@@ -60,13 +63,13 @@ describe('hoodie.id()', function() {
     });
 
     it('unsets hoodieId on account:cleanup', function() {
-      this.hoodie.generateId.returns('currentId');
+      generateIdMock.returns('currentId');
       var currentId = this.id();
       expect(currentId).to.be('currentId');
 
       this.events['account:cleanup']();
       this.hoodie.config.set.reset();
-      this.hoodie.generateId.returns('newId');
+      generateIdMock.returns('newId');
       var newId = this.id();
       
       expect(newId).to.be('newId');

--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -4,6 +4,9 @@ require('../../lib/setup');
 var storeFactory = sinon.stub();
 global.stubRequire('src/lib/store/api', storeFactory);
 
+var generateIdMock = require('../../mocks/utils/generate_id');
+global.stubRequire('src/utils/generate_id', generateIdMock);
+
 var hoodieLocalStore = require('../../../src/hoodie/store');
 var extend = require('extend');
 
@@ -11,6 +14,7 @@ describe('hoodie.store', function() {
 
   beforeEach(function() {
     this.hoodie = this.MOCKS.hoodie.apply(this);
+    generateIdMock.returns('uuid123');
 
     // see https://github.com/pivotal/jasmine/issues/299
     Object.defineProperty(localStorage, 'setItem', { writable: true });

--- a/test/specs/lib/store/remote.spec.js
+++ b/test/specs/lib/store/remote.spec.js
@@ -4,6 +4,9 @@ require('../../../lib/setup');
 var storeFactory = sinon.stub();
 global.stubRequire('src/lib/store/api', storeFactory);
 
+var generateIdMock = require('../../../mocks/utils/generate_id');
+global.stubRequire('src/utils/generate_id', generateIdMock);
+
 global.unstubRequire('src/lib/store/remote');
 var hoodieRemoteStore = require('../../../../src/lib/store/remote');
 
@@ -11,6 +14,7 @@ describe('hoodieRemoteStore', function() {
 
   beforeEach(function() {
     this.hoodie = this.MOCKS.hoodie.apply(this);
+    generateIdMock.returns('uuid123');
 
     this.requestDefer = this.hoodie.defer();
     var promise = this.requestDefer.promise();
@@ -272,13 +276,15 @@ describe('hoodieRemoteStore', function() {
   describe('#save(type, id, object)', function() {
 
     it('should generate an id if it is undefined', function() {
+      generateIdMock.reset();
       this.storeBackend.save({type: 'car'});
-      expect(this.hoodie.generateId).to.be.called();
+      expect(generateIdMock).to.be.called();
     });
 
     it('should not generate an id if id is set', function() {
+      generateIdMock.reset();
       this.storeBackend.save({type: 'car', id: '123'});
-      expect(this.hoodie.generateId).to.not.be.called();
+      expect(generateIdMock).to.not.be.called();
     });
 
     it('should return promise by @request', function() {

--- a/test/specs/utils/generate_id.spec.js
+++ b/test/specs/utils/generate_id.spec.js
@@ -1,20 +1,20 @@
 require('../../lib/setup');
-var hoodieGenerateId = require('../../../src/utils/generate_id');
 
-describe('hoodie.generateId()', function() {
+global.unstubRequire('src/utils/generate_id');
+var generateId = require('../../../src/utils/generate_id');
+
+describe('generateId()', function() {
 
   beforeEach(function() {
-    this.hoodie = this.MOCKS.hoodie.apply(this);
-    hoodieGenerateId(this.hoodie);
   });
 
   it('should default to a length of 7', function() {
-    expect(this.hoodie.generateId().length).to.eql(7);
+    expect(generateId().length).to.eql(7);
   });
 
   _when('called with num = 5', function() {
     it('should generate an id with length = 5', function() {
-      expect(this.hoodie.generateId(5).length).to.eql(5);
+      expect(generateId(5).length).to.eql(5);
     });
   });
 });


### PR DESCRIPTION
as we moved generateId into `/utils` folder, I'd remove it from the public API and make it later on accessible to plugin developers using the Hoodie.extend method
