### PR TITLE
Ensure withSingleRequest is being used for all GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can also subscribe to the following task events
   });
 
   magic.fail(function(eror) {
-    alert('Sory, but something went wrong: ' + error.reason);
+    alert('Sorry, but something went wrong: ' + error.reason);
   });
 
 

--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -472,7 +472,7 @@ function hoodieAccount(hoodie) {
       }
     };
 
-    return withPreviousRequestsAborted('passwordResetStatus', function() {
+    return withSingleRequest('passwordResetStatus', function() {
       return account.request('GET', url, options).then(
       handlePasswordResetStatusRequestSuccess, handlePasswordResetStatusRequestError).fail(function(error) {
         if (error.name === 'HoodiePendingError') {


### PR DESCRIPTION
As per #118 I checked all the current uses of `withSingleRequest` and `withPreviousRequestsAborted` to ensure they we're tied up to the relevant request types. There was only one which wasn't, for `passwordResetStatus`.
