### PR TITLE
Comment fix to (in)valid session

### DIFF
--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -90,8 +90,7 @@ function hoodieAccount(hoodie) {
   // hasValidSession
   // -----------------
 
-  // returns true if the user is currently signed but has no valid session,
-  // meaning that the data cannot be synchronized.
+  // returns true if the user is signed in, and has a valid cookie.
   //
   account.hasValidSession = function() {
     if (!account.hasAccount()) {
@@ -105,8 +104,7 @@ function hoodieAccount(hoodie) {
   // hasInvalidSession
   // -----------------
 
-  // returns true if the user is currently signed but has no valid session,
-  // meaning that the data cannot be synchronized.
+  // returns true if the user is signed in, but does not have a valid cookie 
   //
   account.hasInvalidSession = function() {
     if (!account.hasAccount()) {


### PR DESCRIPTION
I'm not sure if this is any better or worse as regards #226.

It looks right, but I've not done a huge amount of digging into it.

My main question would be whether the idea behind:

if (!account.hasAccount())

Is geared toward whether a user is signed into their account, or whether the user has an account at all? If a user has an account but is not signed in, data can be synchronized behind the scenes for them, but I wouldn't want to be synchronizing anything to a user that wasn't signed in, for fear of shared computers and so on.
