### PR TITLE
anonymousSignUp fails if there are local changes

### DIFF
--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -522,8 +522,9 @@ describe('hoodie.account', function() {
 
                 _and('sign in fails with unauthorized error', function() {
                   beforeEach(function() {
-                    this.signInDefer = getDefer();
-                    this.sandbox.stub(this.account, 'signIn').returns(this.signInDefer.promise());
+                    this.signOutDefer = getDefer();
+                    this.sandbox.stub(this.account, 'signOut').returns(this.signOutDefer.promise());
+
                     this.account.request.reset();
                     this.requestDefers[3].reject({
                       name: 'HoodieUnauthorizedError',
@@ -532,27 +533,43 @@ describe('hoodie.account', function() {
                     });
                   });
 
-                  it('should sign in with new username', function() {
-                    expect(this.account.signIn).to.be.calledWith('joe@example.com', 'secret');
-                  });
-
-                  _and('sign in to new account succeeds', function() {
-                    beforeEach(function() {
-                      this.signInDefer.resolve();
-                    });
-
-                    it('should resolve', function() {
-                      expect(this.promise).to.be.resolved();
+                  it('should sign out silently and ignore local changes', function() {
+                    expect(this.account.signOut).to.be.calledWith({
+                      silent: true,
+                      ignoreLocalChanges: true
                     });
                   });
 
-                  _and('sign in to new account fails', function() {
+                  _and('sign out succeeds', function() {
                     beforeEach(function() {
-                      this.signInDefer.reject('ooops');
+                      this.signInDefer = getDefer();
+                      this.sandbox.stub(this.account, 'signIn').returns(this.signInDefer.promise());
+
+                      this.signOutDefer.resolve();
                     });
 
-                    it('should reject', function() {
-                      expect(this.promise).to.be.rejectedWith('ooops');
+                    it('should sign in with new username', function() {
+                      expect(this.account.signIn).to.be.calledWith('joe@example.com', 'secret');
+                    });
+
+                    _and('sign in to new account succeeds', function() {
+                      beforeEach(function() {
+                        this.signInDefer.resolve();
+                      });
+
+                      it('should resolve', function() {
+                        expect(this.promise).to.be.resolved();
+                      });
+                    });
+
+                    _and('sign in to new account fails', function() {
+                      beforeEach(function() {
+                        this.signInDefer.reject('ooops');
+                      });
+
+                      it('should reject', function() {
+                        expect(this.promise).to.be.rejectedWith('ooops');
+                      });
                     });
                   });
                 });
@@ -1965,8 +1982,9 @@ describe('hoodie.account', function() {
 
             _and('sign in fails with unauthorized error', function() {
               beforeEach(function() {
-                this.signInDefer = getDefer();
-                this.sandbox.stub(this.account, 'signIn').returns(this.signInDefer.promise());
+                this.signOutDefer = getDefer();
+                this.sandbox.stub(this.account, 'signOut').returns(this.signOutDefer.promise());
+
                 this.account.request.reset();
                 this.requestDefers[3].reject({
                   name: 'HoodieUnauthorizedError',
@@ -1975,27 +1993,44 @@ describe('hoodie.account', function() {
                 });
               });
 
-              it('should sign in with new username', function() {
-                expect(this.account.signIn).to.be.calledWith('new.joe@example.com', 'secret');
-              });
-
-              _and('sign in to new account succeeds', function() {
-                beforeEach(function() {
-                  this.signInDefer.resolve();
-                });
-
-                it('should resolve', function() {
-                  expect(this.promise).to.be.resolved();
+              it('should sign out silently and ignore local changes', function() {
+                expect(this.account.signOut).to.be.calledWith({
+                  silent: true,
+                  ignoreLocalChanges: true
                 });
               });
 
-              _and('sign in to new account fails', function() {
+
+              _and('sign out succeeds', function() {
                 beforeEach(function() {
-                  this.signInDefer.reject('ooops');
+                  this.signInDefer = getDefer();
+                  this.sandbox.stub(this.account, 'signIn').returns(this.signInDefer.promise());
+
+                  this.signOutDefer.resolve();
                 });
 
-                it('should reject', function() {
-                  expect(this.promise).to.be.rejectedWith('ooops');
+                it('should sign in with new username', function() {
+                  expect(this.account.signIn).to.be.calledWith('new.joe@example.com', 'secret');
+                });
+
+                _and('sign in to new account succeeds', function() {
+                  beforeEach(function() {
+                    this.signInDefer.resolve();
+                  });
+
+                  it('should resolve', function() {
+                    expect(this.promise).to.be.resolved();
+                  });
+                });
+
+                _and('sign in to new account fails', function() {
+                  beforeEach(function() {
+                    this.signInDefer.reject('ooops');
+                  });
+
+                  it('should reject', function() {
+                    expect(this.promise).to.be.rejectedWith('ooops');
+                  });
                 });
               });
             });


### PR DESCRIPTION
I'm on it. But for reference here the steps to reproduce

``` js
// 1. create an anonymous account, wait until it's done
hoodie.account.anonymousSignUp().then( function() {
  // 2. create an object, this will make hoodie.store.hasLocalChanges() return true
  hoodie.store.add('test', {})
  // 3. This will internally rename the anonymous account to the real account, that
  // includes a call to `hoodie.account.signOut({silent: true})`. signOut has a check
  // if there are local changes. If there are, hoodie tries to push them so no data gets
  // lost on signOut. And in case that fails, it rejects the sign out. And that's what bite's us
  // here. The Push fails with a 401 as the original account for the current session has
  // been removed. And that makes the entire `hoodie.account.signUp()` fail with the
  // akward error "HoodieUnauthorizedError: You are not authorized to access this db"
  hoodie.account.signUp('username', 'password')
  .done( function() { alert('Worked') })
  .fail( function(error) { alert('Failed with ' + error.toString()) })
});
```

To fix that, I'll work around the signOut all together, signing in to new account does the job here
