### PR TITLE
check connection request: add ?hoodieId=abc4567

### DIFF
--- a/src/hoodie/connection.js
+++ b/src/hoodie/connection.js
@@ -34,6 +34,7 @@ function hoodieConnection(hoodie) {
   //
   hoodie.checkConnection = function checkConnection() {
     var req = checkConnectionRequest;
+    var path = '/?hoodieId=' + hoodie.id();
 
     if (req && req.state() === 'pending') {
       return req;
@@ -41,7 +42,7 @@ function hoodieConnection(hoodie) {
 
     global.clearTimeout(checkConnectionTimeout);
 
-    checkConnectionRequest = hoodie.request('GET', '/').then(
+    checkConnectionRequest = hoodie.request('GET', path).then(
       handleCheckConnectionSuccess,
       handleCheckConnectionError
     );

--- a/test/specs/hoodie/connection.spec.js
+++ b/test/specs/hoodie/connection.spec.js
@@ -20,9 +20,9 @@ describe('#checkConnection()', function() {
     expect(this.hoodie).to.have.property('isConnected');
   });
 
-  it('should send GET / request', function() {
+  it('should send GET /hoodieId=<hoodieid> request', function() {
     this.hoodie.checkConnection();
-    expect(this.hoodie.request).to.be.calledWith('GET', '/');
+    expect(this.hoodie.request).to.be.calledWith('GET', '/?hoodieId=hoodieid');
   });
 
   it('should only send one request at a time', function() {


### PR DESCRIPTION
That we one can use the logs to get an idea of how many people are using the app, and also find out when a user has been active. It certainly helps with debugging.

I don't see any downside with this, other thoughts?
