### PR TITLE
do not throw exception when initializing HoodieError without passing a message

### DIFF
--- a/src/lib/error/error.js
+++ b/src/lib/error/error.js
@@ -43,7 +43,7 @@ function HoodieError(properties) {
   }
 
   if (! properties.message) {
-    throw new Error('FATAL: error.message must be set');
+    properties.message = 'Something went wrong';
   }
 
   // must check for properties, as this.name is always set.

--- a/test/specs/lib/error/error.spec.js
+++ b/test/specs/lib/error/error.spec.js
@@ -19,11 +19,9 @@ describe('#HoodieError()', function() {
     var error = new HoodieError({ message: 'There is no Santa Clause' });
     expect(error.name).to.be('HoodieError');
   });
-  it('requires message to be set', function() {
-    var hoodieErrorWithoutMessage = function() {
-      new HoodieError({});
-    };
-    expect(hoodieErrorWithoutMessage).to.throwError(/FATAL: error.message must be set/);
+  it('falls back message to "Something went wrong"', function() {
+    var error = new HoodieError({});
+    expect(error.message).to.be('Something went wrong');
   });
   it('accepts a custom name for the error', function() {
     var error = new HoodieError({name: 'FunkMissingError', message: 'You don\'t have the funk!'});


### PR DESCRIPTION
initially I thought it would be helpful in development of plugins when developers would reject promises without passing a message, but I got bit by that a lot in production, so I'd now rather fallback to a generic error message
