### PR TITLE
options in account.signIn() should default to empty object

### DIFF
--- a/src/hoodie/account.js
+++ b/src/hoodie/account.js
@@ -258,6 +258,8 @@ function hoodieAccount(hoodie) {
     if (! password) { password = ''; }
     username = username.toLowerCase();
 
+    options = options || {};
+
     if (account.hasAccount() && isNotReauthenticating && !options.moveData) {
       return pushLocalChanges().then(function() {
         return sendSignInRequest(username, password, options);


### PR DESCRIPTION
`account.signIn()` is sometimes invoked without passing it an `options` object (as the 3rd argument), so it should default to an empty object to avoid getting a `ReferenceError`.
