### PR TITLE
when local changes get pushed, `change` events from remote get triggered

### DIFF
--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -323,7 +323,7 @@ describe('hoodie.store', function() {
 
       _and('options.silent is true', function() {
         beforeEach(function() {
-
+          this.store.trigger.reset();
           this.storeBackend.save({
             type: 'document',
             id: '123',
@@ -338,6 +338,10 @@ describe('hoodie.store', function() {
           var object = getLastSavedObject();
           expect(object.createdAt).to.be(undefined);
           expect(object.updatedAt).to.be(undefined);
+        });
+
+        it('should not trigger any events', function() {
+          expect(this.store.trigger).to.not.be.called();
         });
       }); // options.silent is true
 

--- a/test/specs/lib/store/remote.spec.js
+++ b/test/specs/lib/store/remote.spec.js
@@ -871,9 +871,9 @@ describe('hoodieRemoteStore', function() {
         });
 
         it('should trigger push events for each object', function() {
-          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '1' });
-          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '2' });
-          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '3' });
+          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '1', _rev: '1-uuid123' });
+          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '2', _rev: '1-uuid123' });
+          expect(this.remote.trigger).to.be.calledWith('push', { type: 'todo', id: '3', _rev: '1-uuid123' });
         });
       });
     }); // Array of docs passed


### PR DESCRIPTION
To reproduce

```
// make sure that you have an account, if not run hoodie.account.anonymousSignUp()

// subscribe to remote changes
hoodie.remote.on('change', function() { console.log('REMOTE CHANGE', arguments) })

// Add a new object
hoodie.store.add('funk', {})

// wait 2s, then you'll see the `REMOTE CHANGE` in the console
```

This issue will become obsolete once we migrate to Pouch (#8), but I think I can fix this with a rather simple fix. 
