### PR TITLE
Declare jQuery dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,9 @@
   "main": [
     "./dist/hoodie.js"
   ],
+  "dependencies": {
+    "jquery": "^1.9.1 || ^2.0.2"
+  },
   "ignore": [
     "test/",
     "src/",


### PR DESCRIPTION
This is necessary for correct bower installs, at least till #9 is fixed.

Edit: I'm not 100% sure, but I think the [failed build](https://travis-ci.org/hoodiehq/hoodie.js/builds/23952561#L2728) is not caused by this change, right? 
