### PR TITLE
Release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,10 +182,9 @@ If you have commit access, please follow this process for merging patches and cu
 
 ### Releasing a new version
 
-1. Include all new functional changes in the CHANGELOG.
-2. Use a dedicated commit to increment the version. The version needs to be
-   added to the `CHANGELOG.md` (inc. date) and the `package.json`.
-3. The commit message must be of `v0.0.0` format.
-4. Create an annotated tag for the version: `git tag -m "v0.0.0" v0.0.0`.
-5. Push the changes and tags to GitHub: `git push --tags origin master`.
-6. Publish the new version to npm: `npm publish`.
+Releasing a new version is automated with `grunt release`.
+You may add flags to specify the new version.
+
+1. `grunt release` or `grunt release:patch`: 0.0.1 => 0.0.2
+2. `grunt release:minor`: 0.0.2 => 0.1.0
+3. `grunt release:major`: 0.1.0 => 1.0.0

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,7 +156,8 @@ module.exports = function(grunt) {
   // load all tasks defined in node_modules starting with 'grunt-'
   require('load-grunt-tasks')(grunt);
 
-  grunt.registerTask('default', ['test']);
-  grunt.registerTask('build', ['jshint', 'karma:continuous', 'browserify:build', 'concat', 'uglify']);
-  grunt.registerTask('test', ['karma:dev']);
+  grunt.registerTask('build', ['browserify:build', 'concat', 'uglify']);
+  grunt.registerTask('test', ['jshint', 'karma:continuous', 'build']);
+  grunt.registerTask('default', ['build']);
+
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,18 +136,19 @@ module.exports = function(grunt) {
     // https://github.com/vojtajina/grunt-bump
     // bump version of hoodie.js
     bump: {
-      versions: {
-        options: {
-          files: ['package.json', 'bower.json'],
-          updateConfigs: ['pkg'],
-          pushTo: 'upstream',
-          commit: true,
-          commitMessage: 'Release %VERSION%',
-          commitFiles: ['-a'], // '-a' for all files
-          createTag: true,
-          tagName: '%VERSION%',
-          tagMessage: 'Version %VERSION%'
-        }
+      options: {
+        commitMessage: 'chore(release): v%VERSION%',
+        files: [
+          'bower.json',
+          'package.json'
+        ],
+        commitFiles: [
+          'dist/*',
+          'bower.json',
+          'package.json',
+          'CHANGELOG.md'
+        ],
+        pushTo: 'origin master'
       }
     }
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,11 +2,12 @@ module.exports = function(grunt) {
 
   'use strict';
 
-  var banner = '// <%= pkg.title %> - <%= pkg.version%>\n';
-  banner += '// https://github.com/hoodiehq/hoodie.js\n';
-  banner += '// Copyright 2012 - 2014 https://github.com/hoodiehq/\n';
-  banner += '// Licensed Apache License 2.0\n';
-  banner += '\n';
+  require('load-grunt-tasks')(grunt);
+
+  var banner = '// <%= pkg.title %> - <%= pkg.version%>\n' +
+    '// https://github.com/hoodiehq/hoodie.js\n' +
+    '// Copyright 2012 - 2014 https://github.com/hoodiehq/\n' +
+    '// Licensed Apache License 2.0\n\n';
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -68,11 +69,11 @@ module.exports = function(grunt) {
             platform: 'mac 10.8',
             browserName: 'safari'
           },
-          //sl_firefox_win7: {
-            //base: 'SauceLabs',
-            //platform: 'Windows 7',
-            //browserName: 'Firefox'
-          //},
+          // sl_firefox_win7: {
+          //   base: 'SauceLabs',
+          //   platform: 'Windows 7',
+          //   browserName: 'Firefox'
+          // },
           // IE 10 & 11 is WIP
           // sl_ie10_win7: {
           //   base: 'SauceLabs',
@@ -91,9 +92,9 @@ module.exports = function(grunt) {
           'PhantomJS',
           'sl_chrome_mac',
           'sl_safari_mac',
-          //'sl_firefox_win7',
-        // 'sl_ie10_win7',
-        // 'sl_ie11_win8'
+          // 'sl_firefox_win7',
+          // 'sl_ie10_win7',
+          // 'sl_ie11_win8'
         ]
       },
 
@@ -151,6 +152,7 @@ module.exports = function(grunt) {
         pushTo: 'origin master'
       }
     }
+
   });
 
   grunt.registerTask('release', function() {
@@ -173,9 +175,6 @@ module.exports = function(grunt) {
     ]);
 
   });
-
-  // load all tasks defined in node_modules starting with 'grunt-'
-  require('load-grunt-tasks')(grunt);
 
   grunt.registerTask('build', ['browserify:build', 'concat', 'uglify']);
   grunt.registerTask('test', ['jshint', 'karma:continuous', 'build']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -153,6 +153,27 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.registerTask('release', function() {
+
+    // forward arguments to the bump-only task
+    this.args.unshift('bump-only');
+
+    // refresh package information
+    grunt.registerTask('refresh', function() {
+      grunt.config.set('pkg', grunt.file.readJSON('package.json'));
+    });
+
+    grunt.task.run([
+      'karma:dev',
+      this.args.join(':'),
+      'refresh',
+      'build',
+      'changelog',
+      'bump-commit'
+    ]);
+
+  });
+
   // load all tasks defined in node_modules starting with 'grunt-'
   require('load-grunt-tasks')(grunt);
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "expect.js": "~0.2.0",
     "sinon": "~1.7.1",
     "load-grunt-tasks": "~0.2.1",
-    "grunt-bump": "0.0.13"
+    "grunt-bump": "0.0.13",
+    "grunt-conventional-changelog": "~1.1.0"
   },
   "scripts": {
     "test": "grunt build --verbose",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "grunt-conventional-changelog": "~1.1.0"
   },
   "scripts": {
-    "test": "grunt build --verbose",
+    "test": "grunt test --verbose",
     "build": "grunt build --verbose"
   }
 }


### PR DESCRIPTION
Basically the same thing as https://github.com/hoodiehq/hoodie-cli/pull/117.

As this package is also available on npm someone™ with the necessary rights should run `travis setup npm`. See [here](https://github.com/hoodiehq/hoodie-cli/blob/master/.travis.yml#L7-L14).

The SauceLabs configuration is broken and fails the build.

@gr2m @svnlto
