### PR TITLE
hoodie.account.username should not be set for anonymous accounts

### DIFF
--- a/src/hoodie/id.js
+++ b/src/hoodie/id.js
@@ -53,6 +53,7 @@ function hoodieId (hoodie) {
     hoodie.on('account:signin', function(username, hoodieId) {
       setId(hoodieId);
     });
+    hoodie.on('account:signin:anonymous', setId);
   }
 
   // allow to run this only once from outside

--- a/src/hoodie/remote.js
+++ b/src/hoodie/remote.js
@@ -124,6 +124,8 @@ function hoodieRemote (hoodie) {
     hoodie.on('reconnected', remote.connect);
 
     // account events
+    hoodie.on('account:signup', remote.connect);
+    hoodie.on('account:signup:anonymous', remote.connect);
     hoodie.on('account:signin', remote.connect);
     hoodie.on('account:signin:anonymous', remote.connect);
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -2,6 +2,7 @@
 // ===================
 
 var localStorageWrapper = require('../utils/local_storage_wrapper');
+var extend = require('extend');
 
 // public API
 var config = {};
@@ -25,7 +26,10 @@ config.set = function set(key, value) {
 // receives a configuration
 //
 config.get = function get(key) {
-  return cache[key];
+  if (key) {
+    return cache[key];
+  }
+  return extend({}, cache);
 };
 
 // clear

--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -10,6 +10,9 @@ global.stubRequire('src/utils/generate_id', generateIdMock);
 var localStorageMock = require('../../mocks/utils/local_storage_wrapper');
 global.stubRequire('src/utils/local_storage_wrapper', localStorageMock);
 
+var configMock = require('../../mocks/utils/config');
+global.stubRequire('src/utils/config', configMock);
+
 var hoodieLocalStore = require('../../../src/hoodie/store');
 var extend = require('extend');
 
@@ -37,6 +40,7 @@ describe('hoodie.store', function() {
     global.unstubRequire('src/lib/store/api');
     global.unstubRequire('src/utils/generate_id');
     global.unstubRequire('src/utils/local_storage_wrapper');
+    global.unstubRequire('src/utils/config');
   });
 
   //
@@ -51,6 +55,68 @@ describe('hoodie.store', function() {
 
     it('can only be run once', function() {
       expect( this.store.subscribeToOutsideEvents ).to.eql(undefined);
+    });
+
+    it('should move data on account:movedata', function() {
+      var objects = [{
+        type: 'item',
+        id: 'abc',
+        title: 'Milk',
+        createdBy: 'oldHoodieId'
+      }, {
+        type: 'item',
+        id: 'def',
+        title: 'Wodka',
+        createdBy: 'oldHoodieId'
+      }, {
+        type: 'item',
+        id: 'ghi',
+        title: 'Funk',
+        createdBy: 'someOtherHoodieId'
+      }];
+      var config = {
+        funky: 'config',
+        '_account.username': 'oldUsername',
+        '_hoodieId': 'somehash'
+      };
+      var signInCallback;
+      this.store.findAll.reset();
+      this.store.findAll.returns(this.hoodie.resolveWith(objects));
+      configMock.get.resetBehavior();
+      configMock.get.returns(config);
+      this.hoodie.one.reset();
+      this.hoodie.id.returns('oldHoodieId');
+
+      this.outsideEvents['account:movedata']();
+      expect(this.store.findAll).to.be.called();
+      expect(this.hoodie.one).to.be.called();
+      expect(this.hoodie.one.args[0][0]).to.be('signin');
+      signInCallback = this.hoodie.one.args[0][1];
+
+      signInCallback('newUsername', 'newHoodieId');
+      expect(configMock.set).to.be.calledWith('funky', 'config');
+      expect(configMock.set).to.not.be.calledWith('_account.username', 'oldUsername');
+      expect(configMock.set).to.not.be.calledWith('_account.username', 'oldUsername');
+      expect(configMock.set).to.not.be.calledWith('_hoodieId', 'somehash');
+
+      expect(this.store.add).to.be.calledWith('item', {
+        type: 'item',
+        id: 'abc',
+        title: 'Milk',
+        createdBy: 'newHoodieId'
+      });
+      expect(this.store.add).to.be.calledWith('item', {
+        type: 'item',
+        id: 'def',
+        title: 'Wodka',
+        createdBy: 'newHoodieId'
+      });
+      expect(this.store.add).to.be.calledWith('item', {
+        type: 'item',
+        id: 'ghi',
+        title: 'Funk',
+        createdBy: 'someOtherHoodieId'
+      });
     });
 
     it('should cleanup on account:cleanup', function() {


### PR DESCRIPTION
Today, we have this 

``` js
hoodie.account.anonymousSignUp().then(function() {
  alert(hoodie.account.username) // alerts something like abc4567
})
```

This is confusing. It's technically correct, and we need to store the username towards the backend somewhere, but we should not expose it in our API. 
