### PR TITLE
hoodie.account #signUp "before each" hook FAILED

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[*.js]
+
+trim_trailing_whitespace = true

--- a/test/specs/hoodie/account.spec.js
+++ b/test/specs/hoodie/account.spec.js
@@ -468,7 +468,9 @@ describe('hoodie.account', function() {
 
             // reset spies
             this.account.request.reset();
-            this.requestDefers = [];
+
+            // do not reset by setting to [], see #304
+            this.requestDefers.length = 0;
 
             //
             promise = this.account.signUp(this.hoodie.id(), 'secret');
@@ -491,10 +493,11 @@ describe('hoodie.account', function() {
         _when('signUp successful', function() {
 
           beforeEach(function() {
-
             // reset spies
             this.account.request.reset();
-            this.requestDefers = [];
+
+            // do not reset by setting to [], see #304
+            this.requestDefers.length = 0;
 
             this.promise = this.account.signUp('joe@example.com', 'secret');
             var response = {
@@ -2078,11 +2081,11 @@ function unconfirmedUserDoc(username) {
   };
 }
 
-// 
+//
 // this is a hack to set the value of the internal userDoc variable.
 // As it's not accessible from outside, we call account.fetch()
 // and fake its response, then reset the hoodie.request stub
-// 
+//
 function presetUserDoc(context) {
   context.account.fetch();
   context.hoodie.request.defer.resolve(unconfirmedUserDoc(context.account.username));
@@ -2118,7 +2121,7 @@ function with_session_validated_before(callback) {
         this.hoodie.request.returns(defer.promise());
         this.hoodie.request.defer = defer;
       }
-      
+
     });
 
     callback();


### PR DESCRIPTION
```
PhantomJS 1.9.7 (Mac OS X) hoodie.account #signUp(username, password) when username set and user is logged out when signUp successful "before each" hook FAILED
    TypeError: 'undefined' is not an object (evaluating 'this.requestDefers[0].resolve')
        at /Users/boennemann/Projects/hoodiehq/hoodie.js/test/specs/hoodie/account.spec.js:737
        at callFn (/Users/boennemann/Projects/hoodiehq/hoodie.js/node_modules/mocha/mocha.js:4338)
        at /Users/boennemann/Projects/hoodiehq/hoodie.js/node_modules/mocha/mocha.js:4331
        at next (/Users/boennemann/Projects/hoodiehq/hoodie.js/node_modules/mocha/mocha.js:4626)
        at /Users/boennemann/Projects/hoodiehq/hoodie.js/node_modules/mocha/mocha.js:4630
        at timeslice (/Users/boennemann/Projects/hoodiehq/hoodie.js/node_modules/mocha/mocha.js:5763)
PhantomJS 1.9.7 (Mac OS X): Executed 585 of 588 (1 FAILED) (7.039 secs / 0.655 secs)
```

[Failing beforeEach hook](https://github.com/hoodiehq/hoodie.js/blob/master/test/specs/hoodie/account.spec.js#L708-L724)
