### PR TITLE
Allow dashes and underscores in type names #296

### DIFF
--- a/src/hoodie/store.js
+++ b/src/hoodie/store.js
@@ -777,7 +777,7 @@ function hoodieStore (hoodie) {
 
 
   // a semantic key consists of a valid type & id, separated by a "/"
-  var semanticIdPattern = new RegExp(/^[a-z$][a-z0-9]+\/[a-z0-9]+$/);
+  var semanticIdPattern = new RegExp(/^[a-z$][a-z0-9-]+\/[a-z0-9]+$/);
   function isSemanticKey(key) {
     return semanticIdPattern.test(key);
   }

--- a/src/lib/error/object_type.js
+++ b/src/lib/error/object_type.js
@@ -20,7 +20,7 @@ function HoodieObjectTypeError(properties) {
 
   return new HoodieError(properties);
 }
-var validTypePattern = /^[a-z$][a-z0-9]+$/;
+var validTypePattern = /^[a-z$][a-z0-9-]+$/;
 HoodieObjectTypeError.isInvalid = function(type, customPattern) {
   return !(customPattern || validTypePattern).test(type || '');
 };


### PR DESCRIPTION
A small change, but it does help when having to come up with task names...

Since nobody has raised any objections in #296 I have added both dashes and underscores. I can confirm I can run tasks with names like `do_this` or `do-that-as-well` as they often appear in "docs" and all seems well.
