### PR TITLE
remote stores can trigger multiple 'connect' events

### DIFF
--- a/src/lib/store/remote.js
+++ b/src/lib/store/remote.js
@@ -287,6 +287,9 @@ function hoodieRemoteStore(hoodie, options) {
     if (name) {
       remoteName = name;
     }
+    if (remote.connected) {
+      return;
+    }
     remote.connected = true;
     remote.trigger('connect');
     return remote.bootstrap().then(function() {


### PR DESCRIPTION
`remote.connect` should not trigger connect or bootstrap when it is already connected.
