### PR TITLE
hoodie.store.findAll filter function argument

### DIFF
--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -67,3 +67,33 @@ describe('hoodie.store setup', function() {
   });
 
 });
+
+describe('hoodie.store.findAll', function() {
+  it('accepts filter function', function(done) {
+    var state = {
+      cachedObject: {
+        'note/123': { type: 'note', id: '123', isPublic: true },
+        'note/456': { type: 'note', id: '456', isPublic: false }
+      },
+      dirty: {},
+      hoodie: {
+        store: {
+          isBootstrapping: function () { return false; },
+          trigger: function() {},
+          index: function() { return ['note/123', 'note/456']; }
+        },
+        id: function() { return 'hoodieid'; }
+      }
+    };
+    var findPublic = function(object) {
+      return object.isPublic;
+    };
+
+    hoodieStore.localStore.findAll(state, findPublic)
+    .done(function(objects) {
+      expect(objects.length).to.be(1);
+      expect(objects[0].id).to.be('123');
+      done();
+    }).catch(done);
+  });
+});

--- a/test/specs/hoodie/store.spec.js
+++ b/test/specs/hoodie/store.spec.js
@@ -2,7 +2,7 @@ require('../../lib/setup');
 
 var hoodieStore = require('../../../src/hoodie/store');
 
-describe('hoodie.remote setup', function() {
+describe('hoodie.store setup', function() {
 
   beforeEach(function () {
     var hoodieEventBindings = this.hoodieEventBindings = {};


### PR DESCRIPTION
I wanted to document the findAll filter function argument as described by @gr2m in hoodiehq/faq/issues/35. But I have an issue here:

The filter function argument seems to have no effect.

``` javascript
// prerequisite: created 5 entries. one with title 'hello'

hoodie.store('todo')
.findAll(function(todo){
  return todo.title === 'hello';
}).done(function(todos) {
    //ERROR: todos.length === 5, expected be 1
});
```

Since which version does findAll accept a filter function? I've tried to run the sample code with "Version: 0.5.1 (node v0.10.28, npm 1.4.13, platform: darwin)". Afaik filter functions do work fine with hoodie.store.updateAll.

Regards,
Dennis
