### PR TITLE
hoodie.task.start should progress with task object

### DIFF
--- a/src/hoodie/task/helpers.js
+++ b/src/hoodie/task/helpers.js
@@ -15,6 +15,10 @@ exports.handleNewTask = function(state, object) {
   var defer = getDefer();
   var taskStore = state.hoodie.store(object.type, object.id);
 
+  taskStore.on('sync', function(object) {
+    defer.notify(object);
+  });
+
   taskStore.on('remove', function(object) {
 
     // remove "$" from type

--- a/src/utils/promise/defer.js
+++ b/src/utils/promise/defer.js
@@ -1,8 +1,8 @@
 /*jshint -W079 */
 var Promise = exports.Promise = (function() {
-  if (typeof global.Promise === 'function') {
-    return global.Promise;
-  }
+  // if (typeof global.Promise === 'function') {
+  //   return global.Promise;
+  // }
   return require('bluebird');
 })();
 
@@ -59,21 +59,19 @@ function wrapPromise (promise) {
   promise.then = function (onResolve, onReject) {
     promise = Promise.prototype.then.call(this,
       passProgressCallbacks(this, onResolve),
-      onReject);
+      passProgressCallbacks(this, onReject));
     wrapPromise(promise);
     promise._progressCallbacks = this._progressCallbacks;
     return promise;
   };
 
   function passProgressCallbacks(promise, callback) {
+    if (! callback) {
+      return null;
+    }
+
     return function() {
-      var newPromise;
-
-      if (! callback) {
-        return;
-      }
-
-      newPromise = callback.apply(promise, arguments);
+      var newPromise = callback.apply(promise, arguments);
       if (newPromise && newPromise._progressCallbacks && promise._progressCallbacks) {
         newPromise._progressCallbacks = newPromise._progressCallbacks.concat(promise._progressCallbacks);
       }


### PR DESCRIPTION
# DO NOT MERGE

I've found an issue with this, I'm on it.

---

it currently progresses with something like

``` js
hoodie.taks.start('test', {}).progress(function(task) {
  // task should be task object with id, type, createdAt etc, but instead is something like
  // {
  //   id: 'org.couchdb.user:user_anonymous/xpyjy50',
  //   rev: '1-72a0f32b32719bca8db387d9e3340184',
  //   ok: true
  // }
});
```
