### PR TITLE
handlers of hoodie.store events do not throw errors

### DIFF
--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -11,10 +11,23 @@ var exports = module.exports = function(hoodie, context, namespace) {
   var emitter = JQEventEmitter.create();
 
   // aliases
-  emitter.trigger = emitter.emit;
   emitter.one = emitter.once;
   emitter.bind = emitter.on;
   emitter.unbind = emitter.off;
+
+  // monkey patch emit with try-catch
+  // because of https://github.com/hoodiehq/hoodie.js/issues/376
+  emitter.trigger = emitter.emit = (function(emit) {
+    return function() {
+      try {
+        emit.apply(emitter, arguments);
+      } catch (error) {
+        setTimeout(function() {
+          throw error;
+        });
+      }
+    };
+  })(emitter.emit);
 
   extend(hoodie, emitter);
 


### PR DESCRIPTION
this is because we have a try / catch around the hoodie.store's internal triggerEvents method.
