### PR TITLE
hoodie.store.find('test', 'nope') to reject with Error Object and correct message

### DIFF
--- a/src/hoodie/store/localstore.js
+++ b/src/hoodie/store/localstore.js
@@ -145,7 +145,9 @@ exports.find = function(state, type, id) {
     if (!object) {
       return rejectWith({
         name: 'HoodieNotFoundError',
-        message: '"{{type}}" with id "{{id}}" could not be found'
+        message: '"{{type}}" with id "{{id}}" could not be found',
+        type: type,
+        id: id
       });
     }
     return resolveWith(object);
@@ -287,7 +289,9 @@ exports.remove = function(state, type, id, options) {
   if (!object) {
     return rejectWith({
       name: 'HoodieNotFoundError',
-      message: '"{{type}}" with id "{{id}}"" could not be found'
+      message: '"{{type}}" with id "{{id}}"" could not be found',
+      type: type,
+      id: id
     });
   }
 


### PR DESCRIPTION
it currently rejects with a string: `HoodieNotFoundError: "undefined" with id "undefined" could not be found'.

Instead, it should reject with an instance of `HoodieNotFoundError` and the properties:

``` js
{
  name: 'HoodieNotFoundError',
  message: '"test" with id "nope" could not be found',
  type: 'test',
  id: 'nope'
}
```

When fixed, enable the according tests in https://github.com/hoodiehq/hoodie-integration-test/blob/master/tests/www/api/store.js.

It's the same with all other store methods, probably all rejected promises in general. Hoodie must always reject with an error object
