### PR TITLE
hoodie.open(dbName).add('test', {}) does not resolve with created object

### DIFF
--- a/src/lib/store/remote/remotestore.js
+++ b/src/lib/store/remote/remotestore.js
@@ -79,17 +79,20 @@ exports.findAll = function(state, type) {
 // save a new object. If it existed before, all properties
 // will be overwritten
 //
-exports.save = function(state, object) {
-  var path;
+exports.save = function(state, properties) {
+  var remoteProperties, path;
 
-  if (!object.id) {
-    object.id = generateId();
+  if (!properties.id) {
+    properties.id = generateId();
   }
 
-  object = helpers.parseForRemote(state, object);
-  path = '/' + encodeURIComponent(object._id);
+  remoteProperties = helpers.parseForRemote(state, properties);
+  path = '/' + encodeURIComponent(remoteProperties._id);
   return state.remote.request('PUT', path, {
-    data: object
+    data: remoteProperties
+  }).then(function(response) {
+    properties._rev = response.rev;
+    return properties;
   });
 };
 


### PR DESCRIPTION
# DO NOT MERGE

Found an issue here, I'm on it

---

``` js
// given a database 'test' exists that I can write to
window.testDb.add('test', {nr: 1}).done(function(object) {
  // object is something like {id:"test/si5m8h2",rev:"1-3b4ec12fd7278aad2a2c762df9b0b76a",ok:true}
  // but should be {type: 'test', id: 'si5m8h2', _rev: '1-3b4ec12fd7278aad2a2c762df9b0b76a', createdAt: '2014-09-07T16:06:11.774Z', updatedAt: '2014-09-07T16:06:11.774Z', createdBy: 'abc4567'}
});
```
