### PR TITLE
Core Components Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,29 @@ That's it! Running `npm start` will now serve a hoodie-app from your `www` folde
 
 Run `npm start -- --help` to see more options.
 
-## Why is there no code in this repo?
+## Why is there no code in this repository?
 
-Hoodie consists of many components that are bundled and tested in this top-level module.
+Hoodie consists of three main components that are integrated and tested altogether in this top-level module.
 
-If you want to read or contribute to the source-code you can get to it in the individual repos.
+1. [**client**](https://github.com/hoodiehq/hoodie-client)  
+   Hoodie’s front-end client for the browser. It integrates the following client modules:
+   1. [client-account](https://github.com/hoodiehq/hoodie-client-account)  
+   2. [client-store](https://github.com/hoodiehq/hoodie-client-store)  
+   3. [client-task](https://github.com/hoodiehq/hoodie-client-task)  
+   4. [client-log](https://github.com/hoodiehq/hoodie-client-log)  
+   5. [client-connection-status](https://github.com/hoodiehq/hoodie-client-connection-status)  
 
-### Core Components
 
-- [**server**](https://github.com/hoodiehq/hoodie-server)
-- [**client**](https://github.com/hoodiehq/hoodie-client)
-- [**admin-dashboard**](https://github.com/hoodiehq/hoodie-admin-dashboard)
+2. [**server**](https://github.com/hoodiehq/hoodie-server)  
+   Hoodie’s magical back-end. It integrates the following hapi plugins:
+   1. [server-account](https://github.com/hoodiehq/hoodie-server-account)
+   2. [server-store](https://github.com/hoodiehq/hoodie-server-store)
+   3. [server-task](https://github.com/hoodiehq/hoodie-server-task)
 
-### Core Plugins
 
-- [**plugin-appconfig**](https://github.com/hoodiehq/hoodie-plugin-appconfig)
-- [**plugin-email**](https://github.com/hoodiehq/hoodie-plugin-email)
-- [**plugin-users**](https://github.com/hoodiehq/hoodie-plugin-users)
+3. [**admin-dashboard**](https://github.com/hoodiehq/hoodie-admin-dashboard)  
+   Hoodie’s built-in admin dashboard web application
+
 
 ## License
 


### PR DESCRIPTION
Here’s my attempt of a simple visualisation of how all the hoodie
modules play together.

Immediately a few things come to my mind:
1. All the descriptions could be the same as the summaries in the
   respective READMEs. Seeing them all at once can help to make
   them more clear.
2. Would be nice to make link to the respective modules
3. I wonder if we should rename the `hapi-couchdb-*-api` repos to just `hapi-couchdb-*`, and the current `hapi-couchdb-*` repos to `hoodie-*-server`. Because that's what they are, servers, that combine the hapi plugins and their client counterparts in isolation. I think that would make much more sense. I know renaming libraries / packages is not a good idea, but now is the time to do it, these are not yet used outside hoodie
4. Naming conventions: maybe we should rename
   - pouchdb-hoodie-store to hoodie-client-store
   - account-client to hoodie-client-account
   
   It might make it less clear that these libraries can be used
   by themselves, but that is not really a problem we have at
   this point. Hoodie is complex enough, everything that can help
   us with even adding a little clarity is worth a lot in my opinion

Also note that hapi-couchdb-store-api & hapi-couchdb-task-api do not yet exist, but I'm on it
