### PR TITLE
[Potentially Breaking] updated hoodie-server to version 16.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hoodie-plugin-appconfig": "^2.0.1",
     "hoodie-plugin-email": "^1.0.0",
     "hoodie-plugin-users": "^2.2.2",
-    "hoodie-server": "11.0.0",
+    "hoodie-server": "16.1.1",
     "hoodie-start": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Dear hoodie maintainer,

[hoodie-server](https://github.com/hoodiehq/hoodie-server), one of your dependencies, just released a new patch -- [16.1.1](https://github.com/hoodiehq/hoodie-server/releases/tag/v16.1.1).
I'm just a bot and unfortunately I can't yet know if that breaks hoodie as well.

Generally if a breaking change appears in a component there are two options:
1. A new version of an accompanying component makes up for the breaking change, so that if they're used together the public API doesn't break.
2. This is an actual breaking change for hoodie as well.

Please try and figure that out with your amazing _human_ brain.

In case of the former please wait for the accompanying component to release its new version and manually update both versions in one commit. You can close this PR.

In case of the latter please document the breaking change by adding another empty commit that declares the breaking change and includes migration instructions.

This could look something like this:

```
git commit --allow-empty
```

The editor opens.

> docs(changelog): declare breaking change
> 
> BREAKING CHANGE: Feature xyz broke in version x.y.z of hoodie-whatever.
> 
> Please use hoodie.foo() instead of hoodie.bar() from now on.

Thank you,

– Bundle Bump Bot :heart:
