### PR TITLE
Fixies

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -138,6 +138,10 @@ getHoodieServer(options, function (error, server, config) {
   log.verbose('app', 'Starting')
 
   server.start(function () {
-    console.log((useEmoji ? emoji.get('dog') + '  ' : '') + 'Your Hoodie app has started on ' + url.format(config.connection))
+    console.log((useEmoji ? emoji.get('dog') + '  ' : '') + 'Your Hoodie app has started on ' + url.format({
+      protocol: 'http',
+      hostname: config.connection.host,
+      port: config.connection.port
+    }))
   })
 })

--- a/bin/start.js
+++ b/bin/start.js
@@ -105,11 +105,6 @@ var args = yargs
   try {
     var pkg = require('../package.json')
     console.log(pkg.version, '\n')
-    _.forEach(pkg.dependencies, function (value, key) {
-      if (!/^hoodie/.test(key)) return
-
-      console.log(key + ': ' + value)
-    })
     process.exit(0)
   } catch (e) {
     process.exit(1)

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "request": "^2.72.0",
     "require-relative": "^0.8.7",
     "semver": "^5.1.0",
+    "vision": "^4.1.0",
     "yargs": "^4.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hoodie/account": "^1.0.0",
+    "@hoodie/admin": "^1.0.1",
     "@hoodie/client": "^4.0.3",
     "@hoodie/store": "^1.0.1",
     "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "coveralls": "^2.11.9",
     "nock": "^8.0.0",
     "nyc": "^6.4.2",
+    "pouchdb-admins": "^1.0.1",
     "proxyquire": "^1.7.4",
     "semantic-release": "^6.2.1",
     "simple-mock": "^0.7.0",

--- a/server/README.md
+++ b/server/README.md
@@ -51,7 +51,7 @@ for account and store related tasks.
 
       > [see below](#account-client)
 
-1. ## store [:octocat:](https://github.com/hoodiehq/hoodie-store#readme) [![Build Status](https://travis-ci.org/hoodiehq/hoodie-store.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-store) [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-store.svg)](https://david-dm.org/hoodiehq/hoodie-store)
+2. ## store [:octocat:](https://github.com/hoodiehq/hoodie-store#readme) [![Build Status](https://travis-ci.org/hoodiehq/hoodie-store.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-store) [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-store.svg)](https://david-dm.org/hoodiehq/hoodie-store)
 
    > Hoodie’s store core module. It combines [store-client](https://github.com/hoodiehq/hoodie-store-client),
      [store-server](https://github.com/hoodiehq/hoodie-store-server) and exposes
@@ -68,7 +68,7 @@ for account and store related tasks.
 
       > [see below](#store-client)
 
-1. ## client [:octocat:](https://github.com/hoodiehq/hoodie-client#readme) [![Build Status](https://travis-ci.org/hoodiehq/hoodie-client.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-client) [![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie-client/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/hoodie-client?branch=master) [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-client.svg)](https://david-dm.org/hoodiehq/hoodie-client)
+3. ## client [:octocat:](https://github.com/hoodiehq/hoodie-client#readme) [![Build Status](https://travis-ci.org/hoodiehq/hoodie-client.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-client) [![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie-client/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/hoodie-client?branch=master) [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-client.svg)](https://david-dm.org/hoodiehq/hoodie-client)
 
    > Hoodie’s front-end client for the browser. It integrates Hoodie’s client
      core modules: [account-client](https://github.com/hoodiehq/hoodie-account-client), [store-client](https://github.com/hoodiehq/hoodie-store),
@@ -109,3 +109,12 @@ for account and store related tasks.
 
       > JavaScript library for logging to the browser console. If available, it
         takes advantage of [CSS-based styling of console log outputs](https://developer.mozilla.org/en-US/docs/Web/API/Console#Styling_console_output).
+
+4. ## admin [:octocat:](https://github.com/hoodiehq/hoodie-admin#readme) [![Build Status](https://travis-ci.org/hoodiehq/hoodie-admin.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-admin) [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-admin.svg)](https://david-dm.org/hoodiehq/hoodie-admin)
+
+   > Hoodie’s built-in Admin Dashboard, built with [Ember.js](http://emberjs.com)
+
+   1. ### <a name="admin-client"></a>admin-client [:octocat:](https://github.com/hoodiehq/hoodie-admin-client#readme) [![Build Status](https://travis-ci.org/hoodiehq/hoodie-admin-client.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-admin-client) [![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie-admin-client/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/hoodie-admin-client?branch=master) [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-admin-client.svg)](https://david-dm.org/hoodiehq/hoodie-account-client)
+
+      > Hoodie’s front-end admin client for the browser. Used in the Admin Dashboard,
+        but can also be used standalone for custom admin dashboard.

--- a/server/config/db/pouchdb.js
+++ b/server/config/db/pouchdb.js
@@ -3,6 +3,10 @@ module.exports = pouchDbConfig
 var existsSync = require('fs').existsSync
 var join = require('path').join
 
+// pouchdb-admins is made to be a PouchDB plugin but does not require a db,
+// so can be used standalone
+var Admins = require('pouchdb-admins').admins
+var get = require('lodash/get')
 var jsonfile = require('jsonfile')
 var randomstring = require('randomstring')
 
@@ -14,19 +18,52 @@ function pouchDbConfig (state, callback) {
     throws: false
   }) || {}
   var secret = store.couch_httpd_auth_secret
+  var adminPassword = get(store, 'admins.admin')
 
   if (!secret) {
     secret = randomstring.generate({
       charset: 'hex'
     })
-    jsonfile.writeFileSync(storePath, Object.assign(store, {
-      couch_httpd_auth_secret: secret
-    }), {spaces: 2})
+
+    if (adminPassword) {
+      jsonfile.writeFileSync(storePath, Object.assign(store, {
+        couch_httpd_auth_secret: secret
+      }), {spaces: 2})
+    }
   }
 
   state.config.db.secret = secret
-  state.config.db.admins = {}
+  state.config.db.admins = store.admins
   state.config.db.authenticationDb = '_users'
 
-  callback(null, state.config)
+  if (adminPassword) {
+    return callback(null, state.config)
+  }
+
+  var admins = new Admins({
+    secret: secret
+  })
+
+  admins.set('admin', 'secret')
+
+  .then(function () {
+    return admins.get('admin')
+  })
+
+  .then(function (doc) {
+    state.config.db.admins = {
+      admin: '-pbkdf2-' + doc.derived_key + ',' + doc.salt + ',10'
+    }
+
+    jsonfile.writeFileSync(storePath, Object.assign(store, {
+      couch_httpd_auth_secret: secret,
+      admins: state.config.db.admins
+    }), {spaces: 2})
+
+    callback(null, state.config)
+  })
+
+  .catch(function (error) {
+    callback(error)
+  })
 }

--- a/server/plugins/public.js
+++ b/server/plugins/public.js
@@ -16,6 +16,10 @@ function register (server, options, next) {
     hoodieVersion = 'development'
   }
 
+  var hoodiePublicPath = path.join(require.resolve('../../package.json'), '..', 'public')
+  var accountPublicPath = path.join(require.resolve('@hoodie/account/package.json'), '..', 'public')
+  var storePublicPath = path.join(require.resolve('@hoodie/store/package.json'), '..', 'public')
+
   server.route([{
     method: 'GET',
     path: '/{p*}',
@@ -28,7 +32,37 @@ function register (server, options, next) {
     }
   }, {
     method: 'GET',
-    path: '/hoodie',
+    path: '/hoodie/{p*}',
+    handler: {
+      directory: {
+        path: hoodiePublicPath,
+        listing: false,
+        index: true
+      }
+    }
+  }, {
+    method: 'GET',
+    path: '/hoodie/account/{p*}',
+    handler: {
+      directory: {
+        path: accountPublicPath,
+        listing: false,
+        index: true
+      }
+    }
+  }, {
+    method: 'GET',
+    path: '/hoodie/store/{p*}',
+    handler: {
+      directory: {
+        path: storePublicPath,
+        listing: false,
+        index: true
+      }
+    }
+  }, {
+    method: 'GET',
+    path: '/hoodie/info.json',
     handler: function (request, reply) {
       reply({
         hoodie: true,
@@ -62,9 +96,10 @@ function register (server, options, next) {
 
     var is404 = response.output.statusCode === 404
     var isHTML = /text\/html/.test(request.headers.accept)
+    var isHoodiePath = /^\/hoodie\//.test(request.path)
 
     // We only care about 404 for html requests...
-    if (!is404 || !isHTML) {
+    if (!is404 || !isHTML || isHoodiePath) {
       return reply.continue()
     }
 

--- a/server/plugins/public.js
+++ b/server/plugins/public.js
@@ -19,6 +19,7 @@ function register (server, options, next) {
   var hoodiePublicPath = path.join(require.resolve('../../package.json'), '..', 'public')
   var accountPublicPath = path.join(require.resolve('@hoodie/account/package.json'), '..', 'public')
   var storePublicPath = path.join(require.resolve('@hoodie/store/package.json'), '..', 'public')
+  var adminPublicPath = path.join(require.resolve('@hoodie/admin/package.json'), '..', 'public')
 
   server.route([{
     method: 'GET',
@@ -56,6 +57,16 @@ function register (server, options, next) {
     handler: {
       directory: {
         path: storePublicPath,
+        listing: false,
+        index: true
+      }
+    }
+  }, {
+    method: 'GET',
+    path: '/hoodie/admin/{p*}',
+    handler: {
+      directory: {
+        path: adminPublicPath,
         listing: false,
         index: true
       }

--- a/server/plugins/public.js
+++ b/server/plugins/public.js
@@ -7,16 +7,11 @@ module.exports.register.attributes = {
 var fs = require('fs')
 var path = require('path')
 
-var relative = require('require-relative')
-
 function register (server, options, next) {
   var app = path.join(options.config.paths.public, 'index.html')
   var hoodieVersion
   try {
-    hoodieVersion = relative(
-      'hoodie/package.json',
-      process.cwd()
-    ).version
+    hoodieVersion = require('hoodie/package.json').version
   } catch (err) {
     hoodieVersion = 'development'
   }

--- a/test/integration/force-gzip-test.js
+++ b/test/integration/force-gzip-test.js
@@ -14,7 +14,7 @@ test('handle forced gzip', function (group) {
       group.error(err, 'hoodie loads without error')
 
       server.inject({
-        url: url.resolve(toUrl(config.connection), 'hoodie'),
+        url: url.resolve(toUrl(config.connection), 'hoodie/info.json'),
         headers: {'Accept-Encoding': 'gzip, deflate'}
       }, testGzip.bind(null, group, server))
     })
@@ -27,7 +27,7 @@ test('handle forced gzip', function (group) {
     }, function (err, server, config) {
       group.error(err, 'hoodie loads without error')
 
-      server.inject({url: url.resolve(toUrl(config.connection), 'hoodie')}, function (res) {
+      server.inject({url: url.resolve(toUrl(config.connection), 'hoodie/info.json')}, function (res) {
         group.notOk(res.headers['content-encoding'])
         server.stop(group.end)
       })
@@ -42,7 +42,7 @@ test('handle forced gzip', function (group) {
       group.error(err, 'hoodie loads without error')
 
       server.inject({
-        url: url.resolve(toUrl(config.connection), 'hoodie?force_gzip=true')
+        url: url.resolve(toUrl(config.connection), 'hoodie/info.json?force_gzip=true')
       }, testGzip.bind(null, group, server))
     })
   })

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -16,7 +16,7 @@ test('smoke test', function (group) {
       group.error(err, 'hoodie starts without error')
 
       request({
-        url: url.resolve(toUrl(config.connection), 'hoodie'),
+        url: url.resolve(toUrl(config.connection), 'hoodie/info.json'),
         json: true
       }, function (error, res, data) {
         group.error(error, 'no error on request')

--- a/test/unit/config/db-pouchdb-test.js
+++ b/test/unit/config/db-pouchdb-test.js
@@ -16,6 +16,7 @@ test('generate couch config', function (group) {
             couch_httpd_auth_secret: 'a'
           }
         },
+        writeFileSync: function () {},
         '@noCallThru': true
       }
     })


### PR DESCRIPTION
- adds https://github.com/hoodiehq/hoodie-admin & https://github.com/hoodiehq/hoodie-admin-client to architecture docs
- serves generic UIs from Hoodie Account/Store
- sets admin password to "secret" when using PouchDB (will create follow up issue)
- log correct address to terminal when started
