### PR TITLE
docs(README): add needed npm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you have any questions come say hi in our [chat](http://hood.ie/chat/).
 ## Setup
 
 Hoodie is a [Node.js](https://nodejs.org/en/) package. You need Node Version 4
-or higher, check your installed version with `node -v`.
+or higher and npm Version 2 or higher, check your installed version with `node -v` and 'npm -v'.
 
 First, create a folder and a [package.json](https://docs.npmjs.com/files/package.json) file
 


### PR DESCRIPTION
Docs were missing the earliest supported npm version. Tried to follow AngularJS commit conventions. Please let me know if I did anything wrong.
