### PR TITLE
Update npm-v to be formatted as code block in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you have any questions come say hi in our [chat](http://hood.ie/chat/).
 ## Setup
 
 Hoodie is a [Node.js](https://nodejs.org/en/) package. You need Node Version 4
-or higher and npm Version 2 or higher, check your installed version with `node -v` and 'npm -v'.
+or higher and npm Version 2 or higher, check your installed version with `node -v` and `npm -v`.
 
 First, create a folder and a [package.json](https://docs.npmjs.com/files/package.json) file
 


### PR DESCRIPTION
I updated the section in the README under setup about checking the version of npm.  It currently reads as "check your installed version with `node-v` and 'npm-v'."  I updated the npm-v to follow the same formatting of node-v.  The text will now read as "check your installed version with `node-v` and `npm-v`."

P.S. I apologize if my commit message or this request did not meet exactly all the guidelines in the contributing file.  I tried my best to follow them!  Thanks!
