### PR TITLE
Use `hapi-cors-headers` to correctly respond to OPTIONS requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "good-squeeze": "^3.0.1",
     "h2o2": "^5.1.0",
     "hapi": "^13.3.0",
+    "hapi-cors-headers": "^1.0.0",
     "inert": "^4.0.0",
     "joi": "^8.0.5",
     "jsonfile": "^2.3.0",

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ var bundleClient = require('./bundle-client')
 var getConfig = require('./config')
 var registerPlugins = require('./plugins')
 var userDatabases = require('./utils/user-databases')
+var corsHeaders = require('hapi-cors-headers')
 
 function getHoodieServer (options, callback) {
   getConfig(options, function (error, config) {
@@ -27,6 +28,7 @@ function getHoodieServer (options, callback) {
 
     var server = new hapi.Server(hapiConfig)
     server.connection(config.connection)
+    server.ext('onPreResponse', corsHeaders)
 
     async.parallel([
       registerPlugins.bind(null, server, config),


### PR DESCRIPTION
@gr2m

Related to Issue #493
