### PR TITLE
Generate client bundle using url from hoodie host and port config

### DIFF
--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -3,6 +3,7 @@ module.exports = bundleClient
 var fs = require('fs')
 
 var parallel = require('async').parallel
+var defaultsDeep = require('lodash').defaultsDeep
 
 /**
  * we compare the mtime (modified time) for the Hoodie client and the target
@@ -58,6 +59,13 @@ function buildBundle (config, hoodieClientPath, callback) {
       return callback(error)
     }
 
+    if (config.connection) {
+      defaultsDeep(config, {
+        client: {
+          url: 'http://' + config.connection.host + ':' + config.connection.port
+        }
+      })
+    }
     var options = config.client ? JSON.stringify(config.client) : ''
     var initBuffer = Buffer('\n\nhoodie = new Hoodie(' + options + ')')
 

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -37,12 +37,17 @@ test('bundle client', function (group) {
       }
     })
 
-    bundleClient('client.js', 'bundle.js', {}, function (error, buffer) {
+    bundleClient('client.js', 'bundle.js', {
+      connection: {
+        host: '127.0.0.1',
+        port: 8080
+      }
+    }, function (error, buffer) {
       t.error(error)
 
       t.is(readFileMock.callCount, 1, 'readFile called once')
       t.is(readFileMock.lastCall.arg, 'client.js', 'read bundle')
-      t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie()')
+      t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie({"url":"http://127.0.0.1:8080"})')
 
       t.end()
     })


### PR DESCRIPTION
This would fix #519

The only problem is the hardcoded protocol (http), it would be better if Hoodie constructor accepted an protocol-agnostic url like this `new Hoodie('//127.0.0.1:8080')`, but currently it doesn't work, could be tackled on a future PR

Another solution (which I prefer, but would have more impact) would be stop instantiating hoodie on `client.js`, and let users do the `new Hoodie(opts)`
