### PR TITLE
options.url

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ App-specific default values can be set in `package.json` in `"hoodie": {}`, e.g.
 
 option        | default       | description
 ------------- | ------------- | -------------
+bindAddress   | `'127.0.0.1'` | Address that Hoodie binds to
+data          | `'.hoodie'`   | Data path
+dbUrl         | –             | If provided, uses external CouchDB. URL has to contain credentials.
+inMemory      | `false`       | Whether to start the PouchDB Server in memory
 loglevel      | `'warn'`      | One of: error, warn, info, verbose, silly
 port          | `8080`        | Port-number to run the Hoodie App on
-bindAddress   | `'127.0.0.1'` | Address that Hoodie binds to
 public        | `'public'`    | path to static assets
-inMemory      | `false`       | Whether to start the PouchDB Server in memory
-dbUrl         | –             | If provided, uses external CouchDB. URL has to contain credentials.
-data          | `'.hoodie'`   | Data path
 
 Hoodie is using the [rc](https://www.npmjs.com/package/rc) module to retrieve
 configuration from CLI arguments, environment variables and configuration files.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ inMemory      | `false`       | Whether to start the PouchDB Server in memory
 loglevel      | `'warn'`      | One of: error, warn, info, verbose, silly
 port          | `8080`        | Port-number to run the Hoodie App on
 public        | `'public'`    | path to static assets
+url           | -             | Optional: external URL at which Hoodie Server is accessible
 
 Hoodie is using the [rc](https://www.npmjs.com/package/rc) module to retrieve
 configuration from CLI arguments, environment variables and configuration files.

--- a/server/config/parse-options.js
+++ b/server/config/parse-options.js
@@ -36,13 +36,16 @@ function parseOptions (options, appOptions, callback) {
     connection: {
       host: options.bindAddress,
       port: options.port
-    },
-    db: {}
+    }
   }
 
   defaultsDeep(config, getDefaults())
 
   log.level = config.loglevel
+
+  if (options.url) {
+    config.url = options.url
+  }
 
   if (options.dbUrl) {
     config.db.url = options.dbUrl

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -58,7 +58,7 @@ function buildBundle (config, hoodieClientPath, callback) {
       return callback(error)
     }
 
-    var options = config.client ? JSON.stringify(config.client) : ''
+    var options = config.url ? '{url: "' + config.url + '"}' : ''
     var initBuffer = Buffer('\n\nhoodie = new Hoodie(' + options + ')')
 
     callback(null, Buffer.concat([clientBuffer, initBuffer]))

--- a/test/unit/config/parse-options-test.js
+++ b/test/unit/config/parse-options-test.js
@@ -13,7 +13,9 @@ var getDefaultsMock = function () {
     connection: {
       host: 'host name',
       port: 'app port'
-    }
+    },
+    db: {},
+    client: {}
   }
 }
 getDefaultsMock['@noCallThru'] = true
@@ -36,6 +38,7 @@ test('parse options', function (group) {
     var config = parseOptions({})
 
     t.is(config.name, 'foo', 'sets config.name from defaults')
+    t.is(config.url, undefined, 'does not set config.url by default')
     t.is(config.paths.data, 'data path', 'sets config.paths.data from defaults')
     t.is(config.paths.public, 'public path', 'sets config.public.data from defaults')
     t.is(config.connection.host, 'host name', 'sets config.connection.host from defaults')
@@ -50,10 +53,12 @@ test('parse options', function (group) {
       data: 'options.data',
       public: 'options.public',
       bindAddress: 'options.bindAddress',
-      port: 'options.port'
+      port: 'options.port',
+      url: 'options.url'
     })
 
     t.is(config.paths.data, 'options.data', 'uses data option as data path')
+    t.is(config.url, 'options.url', 'sets config.url from options.url')
     t.is(config.paths.public, 'options.public', 'uses public option as public path')
     t.is(config.connection.host, 'options.bindAddress', 'sets config.connection.host from options.bindAddress')
     t.is(config.connection.port, 'options.port', 'sets config.connection.port from options.port')

--- a/test/unit/config/parse-options-test.js
+++ b/test/unit/config/parse-options-test.js
@@ -32,20 +32,20 @@ var parseOptions = proxyquire('../../../server/config/parse-options', {
 })
 
 test('parse options', function (group) {
-  group.test('defaults', function (group) {
+  group.test('defaults', function (t) {
     var config = parseOptions({})
 
-    group.is(config.name, 'foo', 'sets config.name from defaults')
-    group.is(config.paths.data, 'data path', 'sets config.paths.data from defaults')
-    group.is(config.paths.public, 'public path', 'sets config.public.data from defaults')
-    group.is(config.connection.host, 'host name', 'sets config.connection.host from defaults')
-    group.is(config.connection.port, 'app port', 'sets config.connection.port from defaults')
-    group.is(config.db.prefix, 'data path/data' + pathSeperator, 'sets config.db.prefix based on default data path')
+    t.is(config.name, 'foo', 'sets config.name from defaults')
+    t.is(config.paths.data, 'data path', 'sets config.paths.data from defaults')
+    t.is(config.paths.public, 'public path', 'sets config.public.data from defaults')
+    t.is(config.connection.host, 'host name', 'sets config.connection.host from defaults')
+    t.is(config.connection.port, 'app port', 'sets config.connection.port from defaults')
+    t.is(config.db.prefix, 'data path/data' + pathSeperator, 'sets config.db.prefix based on default data path')
 
-    group.end()
+    t.end()
   })
 
-  group.test('overwrites', function (group) {
+  group.test('overwrites', function (t) {
     var config = parseOptions({
       data: 'options.data',
       public: 'options.public',
@@ -53,32 +53,32 @@ test('parse options', function (group) {
       port: 'options.port'
     })
 
-    group.is(config.paths.data, 'options.data', 'uses data option as data path')
-    group.is(config.paths.public, 'options.public', 'uses public option as public path')
-    group.is(config.connection.host, 'options.bindAddress', 'sets config.connection.host from options.bindAddress')
-    group.is(config.connection.port, 'options.port', 'sets config.connection.port from options.port')
+    t.is(config.paths.data, 'options.data', 'uses data option as data path')
+    t.is(config.paths.public, 'options.public', 'uses public option as public path')
+    t.is(config.connection.host, 'options.bindAddress', 'sets config.connection.host from options.bindAddress')
+    t.is(config.connection.port, 'options.port', 'sets config.connection.port from options.port')
 
-    group.end()
+    t.end()
   })
 
-  group.test('dbUrl', function (group) {
+  group.test('dbUrl', function (t) {
     var config = parseOptions({
       dbUrl: 'http://foo:bar@baz.com'
     })
 
-    group.is(config.db.url, 'http://foo:bar@baz.com', 'Sets config.db.url')
+    t.is(config.db.url, 'http://foo:bar@baz.com', 'Sets config.db.url')
 
-    group.end()
+    t.end()
   })
 
-  group.test('inMemory', function (group) {
+  group.test('inMemory', function (t) {
     var config = parseOptions({
       inMemory: true
     })
 
-    group.is(config.db.db, memdownMock, 'Sets config.db.db to memdown')
+    t.is(config.db.db, memdownMock, 'Sets config.db.db to memdown')
 
-    group.end()
+    t.end()
   })
 
   group.end()

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -64,13 +64,11 @@ test('bundle client', function (group) {
     })
 
     bundleClient('client.js', 'bundle.js', {
-      client: {
-        foo: 'bar'
-      }
+      url: 'https://myapp.com'
     }, function (error, buffer) {
       t.error(error)
 
-      t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie({"foo":"bar"})')
+      t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie({url: "https://myapp.com"})')
 
       t.end()
     })


### PR DESCRIPTION
Set `config.url` from `options.url` and pass it to the client bundle. Follow up for https://github.com/hoodiehq/hoodie/pull/520#issuecomment-230170420.

closes #521
