### PR TITLE
feat: use browserify to bundle hoodie client (#532)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@hoodie/store": "^1.0.1",
     "async": "^2.0.0",
     "boom": "^3.1.2",
+    "browserify": "^13.0.1",
     "good": "^6.6.3",
     "good-squeeze": "^4.0.0",
     "h2o2": "^5.1.0",

--- a/server/plugins/client/index.js
+++ b/server/plugins/client/index.js
@@ -12,7 +12,7 @@ var log = require('npmlog')
 
 function register (server, options, next) {
   var hoodieClientModulePath = path.dirname(require.resolve('@hoodie/client/package.json'))
-  var hoodieClientPath = path.join(hoodieClientModulePath, 'dist/hoodie.js')
+  var hoodieClientPath = path.join(hoodieClientModulePath, 'index.js')
   var bundleTargetPath = path.join(options.config.paths.data, 'client.js')
   var bundlePromise
 

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -23,10 +23,17 @@ test('bundle client', function (group) {
   })
 
   group.test('bundle does not exist', function (t) {
-    var readFileMock = simple.stub().callbackWith(null, new Buffer('hoodie client content'))
+    var bundleMock = simple.stub().callbackWith(null, new Buffer('hoodie client content'))
+    var requireMock = simple.stub()
+
     var bundleClient = proxyquire('../../server/plugins/client/bundle', {
+      browserify: function () {
+        return {
+          bundle: bundleMock,
+          require: requireMock
+        }
+      },
       fs: {
-        readFile: readFileMock,
         stat: simple.stub().callFn(function (path, callback) {
           if (path === 'client.js') {
             return callback(null, {mtime: new Date()})
@@ -40,8 +47,8 @@ test('bundle client', function (group) {
     bundleClient('client.js', 'bundle.js', {}, function (error, buffer) {
       t.error(error)
 
-      t.is(readFileMock.callCount, 1, 'readFile called once')
-      t.is(readFileMock.lastCall.arg, 'client.js', 'read bundle')
+      t.is(requireMock.lastCall.arg, 'client.js', 'require client')
+      t.is(bundleMock.callCount, 1, 'bundle called once')
       t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie()')
 
       t.end()
@@ -49,10 +56,17 @@ test('bundle client', function (group) {
   })
 
   group.test('with client options', function (t) {
-    var readFileMock = simple.stub().callbackWith(null, new Buffer('hoodie client content'))
+    var bundleMock = simple.stub().callbackWith(null, new Buffer('hoodie client content'))
+    var requireMock = simple.stub()
+
     var bundleClient = proxyquire('../../server/plugins/client/bundle', {
+      browserify: function () {
+        return {
+          bundle: bundleMock,
+          require: requireMock
+        }
+      },
       fs: {
-        readFile: readFileMock,
         stat: simple.stub().callFn(function (path, callback) {
           if (path === 'client.js') {
             return callback(null, {mtime: new Date()})


### PR DESCRIPTION
This makes the `/hoodie/client.js` request use Browserify to bundle an up to date version of @hoodie/account-client instead of delivering the prebuilt version in `/dist`.

For more details see issue #532.
