### PR TITLE
fix: don't modify the passed options object

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,10 +10,12 @@ var corsHeaders = require('hapi-cors-headers')
 var hoodieServer = require('@hoodie/server').register
 var log = require('npmlog')
 var PouchDB = require('pouchdb-core')
+var cloneDeep = require('lodash').cloneDeep
 
 var registerPlugins = require('./plugins')
 
 function register (server, options, next) {
+  options = cloneDeep(options)
   if (!options.db) {
     options.db = {}
   }

--- a/test/integration/server-test.js
+++ b/test/integration/server-test.js
@@ -32,6 +32,19 @@ test('server with options.db.url lacking auth', function (t) {
   })
 })
 
+test('does not modify the passed options object', function (t) {
+  var options = {
+    db: {
+      url: 'http://admin:admin@localhost:5984'
+    }
+  }
+
+  hapiPlugin.register(serverMock, options, function () {})
+
+  t.is(options.db.url, 'http://admin:admin@localhost:5984')
+  t.end()
+})
+
 test('server with empty options (#554)', function (t) {
   hapiPlugin.register(serverMock, {}, function (error, config) {
     t.error(error)


### PR DESCRIPTION
So in this project we're registering multiple servers as to Hapi, kinda like this:

``` js
var options = {
  db: {
    url: process.env.COUCH_URL
  }
}

server.register([
  { register: hoodie, options: options },
  { register: otherEndpoint, options: options }
], function (error) {})
```

the problem is, due to hoodie server's behaviour here, `otherEndpoint` never sees what's in `options.db` and will always have an empty object.

This PR fixes this behaviour by cloning the options object before doing anything on it.
