### PR TITLE
Re-enable logging

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -58,19 +58,17 @@ function register (server, options, next) {
   options.PouchDB = PouchDB.defaults(options.db)
   delete options.db
 
-  server.register({
-    register: hoodieServer,
-    options: options
-  }, function (error) {
+  server.ext('onPreResponse', corsHeaders)
+
+  registerPlugins(server, options, function (error) {
     if (error) {
       return next(error)
     }
 
-    server.ext('onPreResponse', corsHeaders, {
-      sandbox: 'plugin'
-    })
-
-    registerPlugins(server, options, function (error) {
+    server.register({
+      register: hoodieServer,
+      options: options
+    }, function (error) {
       if (error) {
         return next(error)
       }

--- a/server/plugins/client/index.js
+++ b/server/plugins/client/index.js
@@ -13,7 +13,7 @@ var log = require('npmlog')
 function register (server, options, next) {
   var hoodieClientModulePath = path.dirname(require.resolve('@hoodie/client/package.json'))
   var hoodieClientPath = path.join(hoodieClientModulePath, 'index.js')
-  var bundleTargetPath = path.join(options.config.paths.data, 'client.js')
+  var bundleTargetPath = path.join(options.config.data || '.hoodie', 'client.js')
   var bundlePromise
 
   // TODO: add /hoodie/client.min.js path

--- a/server/plugins/logger.js
+++ b/server/plugins/logger.js
@@ -66,8 +66,7 @@ function logger (event) {
   }
 
   if (event.event === 'request' || event.event === 'log') {
-    var level = findLogLevel(log.levels, event.tags) || 'verbose'
-
+    var level = findLogLevel(Object.keys(log.levels), event.tags) || 'verbose'
     return log[level](
       event.event,
       new Date(event.timestamp).toISOString(),

--- a/server/plugins/public.js
+++ b/server/plugins/public.js
@@ -8,7 +8,8 @@ var fs = require('fs')
 var path = require('path')
 
 function register (server, options, next) {
-  var app = path.join(options.config.paths.public, 'index.html')
+  var publicFolder = options.config.public || 'public'
+  var app = path.join(publicFolder, 'index.html')
   var hoodieVersion
   try {
     hoodieVersion = require('hoodie/package.json').version
@@ -26,7 +27,7 @@ function register (server, options, next) {
     path: '/{p*}',
     handler: {
       directory: {
-        path: options.config.paths.public,
+        path: publicFolder,
         listing: false,
         index: true
       }


### PR DESCRIPTION
closes #572 

Problem was that we registered the `@hoodie/server` plugin before registering the logger plugin, and by default hapi doesn’t do anything when doing `server.log`
