### PR TITLE
Rename "bindAddress" option to "address"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Available CLI options are
 
 option                    | default       | description
 ------------------------- | ------------- | -------------
-`--bindAddress`           | `'127.0.0.1'` | Address that Hoodie binds to
+`--address`               | `'127.0.0.1'` | Address to which Hoodie binds
 `--data`                  | `'.hoodie'`   | Data path
 `--dbUrl`                 | –             | If provided, uses external CouchDB. URL has to contain credentials.
 `--loglevel`              | `'warn'`      | One of: silent, error, warn, http, info, verbose, silly

--- a/cli/hapi-options.js
+++ b/cli/hapi-options.js
@@ -7,7 +7,7 @@ function getHapiOptions (options) {
     server: {},
     connection: {
       port: options.port,
-      address: options.bindAddress
+      address: options.address
     }
   }
 

--- a/cli/hoodie-defaults.js
+++ b/cli/hoodie-defaults.js
@@ -2,7 +2,7 @@ module.exports = getHoodieDefaults
 
 function getHoodieDefaults () {
   return {
-    bindAddress: '127.0.0.1',
+    address: '127.0.0.1',
     port: 8080,
     data: '.hoodie',
     public: 'public',

--- a/cli/options.js
+++ b/cli/options.js
@@ -1,5 +1,6 @@
 module.exports = getCliOptions
 
+var log = require('npmlog')
 var pick = require('lodash').pick
 var rc = require('rc')
 var yargs = require('yargs')
@@ -37,10 +38,14 @@ function getCliOptions (projectPath) {
         default: defaults.port,
         describe: 'Port-number to run the Hoodie App on'
       },
+      address: {
+        type: 'string',
+        default: defaults.address,
+        describe: 'Address to which Hoodie binds'
+      },
       bindAddress: {
         type: 'string',
-        default: defaults.bindAddress,
-        describe: 'Address that Hoodie binds to'
+        describe: '[DEPRECATED] Address to which Hoodie binds (see --address)'
       },
       data: {
         type: 'string',
@@ -87,6 +92,11 @@ function getCliOptions (projectPath) {
     .epilogue('Options can also be specified as environment variables (prefixed with "hoodie_") or inside a ".hoodierc" file (json or ini).')
     .wrap(Math.min(150, yargs.terminalWidth()))
     .argv
+
+  if (options.bindAddress) {
+    log.warn('The use of --bindAddress is deprecated. Use the --address option instead.')
+    options.address = options.bindAddress
+  }
 
   // rc & yargs are setting keys we are not interested in, like in-memory or _
   // so we only pick the relevant ones based on they keys of the default options.


### PR DESCRIPTION
To align with hapi's server.connection options, rename Hoodie's `bindAddress` command line option to `address`.  Update documentation accordingly and log a deprecation warning.

Closes hoodiehq/hoodie-server#496.
