### PR TITLE
Enable request logging to prevent error

### DIFF
--- a/cli/hapi-options.js
+++ b/cli/hapi-options.js
@@ -7,7 +7,8 @@ function getHapiOptions (options) {
     server: {},
     connection: {
       port: options.port,
-      address: options.address
+      address: options.address,
+      routes: { log: true }
     }
   }
 


### PR DESCRIPTION
Enable request logging in hapi to prevent error during Travis CI builds.

Closes #599.
