### PR TITLE
Callback error invocation

### DIFF
--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -61,7 +61,9 @@ function buildBundle (config, hoodieClientPath, callback) {
   var bundleEE = new EventEmitter()
 
   bundleEE.on('done', function (error, buffer) {
-    if (error) throw error
+    if (error) {
+      return callback(error)
+    }
 
     var options = config.url ? '{url: "' + config.url + '"}' : ''
     var initBuffer = Buffer('\n\nhoodie = new Hoodie(' + options + ')')

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -106,12 +106,12 @@ test('bundle client', function (group) {
   })
 
   group.test('browserify.build failing throws error', function (t) {
-    var error = new Error('TestError')
+    var testError = new Error('TestError')
 
     var bundleClient = proxyquire('../../server/plugins/client/bundle', {
       browserify: function () {
         return {
-          bundle: simple.stub().callbackWith(error),
+          bundle: simple.stub().callbackWith(testError),
           require: simple.stub()
         }
       },
@@ -120,11 +120,11 @@ test('bundle client', function (group) {
       }
     })
 
-    t.throws(function () {
-      bundleClient('client.js', 'bundle.js', {}, simple.stub())
-    }, error)
-    t.end()
+    bundleClient('client.js', 'bundle.js', {}, function (error) {
+      t.ok(error)
+      t.equal(error, testError)
+      t.end()
+    })
   })
-
   group.end()
 })


### PR DESCRIPTION
A fix for #596 

Invokes callback with error in browserify.bundle, and adjusts unit test plugins-client-bundle to expect the error not a thrown error. 👍
