### PR TITLE
fix(set-to-localhost): set host to localhost if options.url not set

### DIFF
--- a/cli/hapi-options.js
+++ b/cli/hapi-options.js
@@ -21,6 +21,8 @@ function getHapiOptions (options) {
 
   if (options.url) {
     hapiOptions.connection.host = url.parse(options.url).hostname
+  } else {
+    hapiOptions.connection.host = 'localhost'
   }
 
   return hapiOptions


### PR DESCRIPTION
closes #541 

Setting to 'localhost' will output  `http://localhost:8080/` instead of default operating system hostname.
