### PR TITLE
Refactor client/index.js for better testability

### DIFF
--- a/server/plugins/client/bundle-handler-factory.js
+++ b/server/plugins/client/bundle-handler-factory.js
@@ -1,0 +1,32 @@
+module.exports = createBundleHandler
+
+var log = require('npmlog')
+
+var bundleClient = require('./bundle')
+var writeClientBundle = require('./bundle-writer')
+
+function createBundleHandler (hoodieClientPath, bundleTargetPath, bundleConfig) {
+  var bundlePromise
+
+  return function (request, reply) {
+    if (!bundlePromise) {
+      bundlePromise = new Promise(function (resolve, reject) {
+        log.silly('client', 'bundling')
+        bundleClient(hoodieClientPath, bundleTargetPath, bundleConfig, function (error, bundleBuffer, hasUpdate) {
+          if (error) {
+            return reject(error)
+          }
+
+          writeClientBundle(hasUpdate, bundleConfig.inMemory, bundleTargetPath, bundleBuffer)
+
+          resolve(bundleBuffer)
+        })
+      })
+    }
+
+    bundlePromise.then(function (buffer) {
+      reply(buffer).bytes(buffer.length).type('application/javascript')
+    }).catch(reply)
+  }
+}
+

--- a/server/plugins/client/bundle-writer.js
+++ b/server/plugins/client/bundle-writer.js
@@ -1,0 +1,29 @@
+module.exports = writeClientBundle
+
+var fs = require('fs')
+
+var log = require('npmlog')
+
+function writeClientBundle (hasUpdate, inMemory, bundleTargetPath, bundleBuffer) {
+  if (!hasUpdate) {
+    log.info('client', 'bundle is up to date')
+    return
+  }
+
+  if (inMemory) {
+    log.silly('client', 'running in memory, not writing bundle to ' + bundleTargetPath)
+    return
+  }
+
+  log.info('client', 'bundle is out of date')
+  log.silly('client', 'writing bundle to ' + bundleTargetPath)
+  fs.writeFile(bundleTargetPath, bundleBuffer, function (error) {
+    if (error) {
+      log.warn('client', 'could not write to ' + bundleTargetPath + '. Bundle cannot be cached and will be re-generated on server restart')
+      return
+    }
+
+    log.info('client', 'bundle written to ' + bundleTargetPath)
+  })
+}
+

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -73,3 +73,4 @@ function buildBundle (config, hoodieClientPath, callback) {
 
   browserify.bundle(bundleEE.emit.bind(bundleEE, 'done'))
 }
+

--- a/server/plugins/client/index.js
+++ b/server/plugins/client/index.js
@@ -4,17 +4,14 @@ module.exports.register.attributes = {
   dependencies: 'inert'
 }
 
-var fs = require('fs')
 var path = require('path')
 
-var bundleClient = require('./bundle')
-var log = require('npmlog')
+var createBundleHandler = require('./bundle-handler-factory')
 
 function register (server, options, next) {
   var hoodieClientModulePath = path.dirname(require.resolve('@hoodie/client/package.json'))
   var hoodieClientPath = path.join(hoodieClientModulePath, 'index.js')
   var bundleTargetPath = path.join(options.config.data || '.hoodie', 'client.js')
-  var bundlePromise
 
   // TODO: add /hoodie/client.min.js path
   // https://github.com/hoodiehq/hoodie-client/issues/34
@@ -22,51 +19,9 @@ function register (server, options, next) {
   server.route([{
     method: 'GET',
     path: '/hoodie/client.js',
-    handler: function (request, reply) {
-      if (!bundlePromise) {
-        bundlePromise = new Promise(function (resolve, reject) {
-          log.silly('client', 'bundling')
-          bundleClient(hoodieClientPath, bundleTargetPath, options.config, function (error, bundleBuffer, hasUpdate) {
-            if (error) {
-              return reject(error)
-            }
-
-            writeClientBundle(hasUpdate, options.config.inMemory, bundleTargetPath, bundleBuffer)
-
-            resolve(bundleBuffer)
-          })
-        })
-      }
-
-      bundlePromise.then(function (buffer) {
-        reply(buffer).bytes(buffer.length).type('application/javascript')
-      }).catch(reply)
-    }
+    handler: createBundleHandler(hoodieClientPath, bundleTargetPath, options.config)
   }])
 
   next()
-}
-
-function writeClientBundle (hasUpdate, inMemory, bundleTargetPath, bundleBuffer) {
-  if (!hasUpdate) {
-    log.info('client', 'bundle is up to date')
-    return
-  }
-
-  if (inMemory) {
-    log.silly('client', 'running in memory, not writing bundle to ' + bundleTargetPath)
-    return
-  }
-
-  log.info('client', 'bundle is out of date')
-  log.silly('client', 'writing bundle to ' + bundleTargetPath)
-  fs.writeFile(bundleTargetPath, bundleBuffer, function (error) {
-    if (error) {
-      log.warn('client', 'could not write to ' + bundleTargetPath + '. Bundle cannot be cached and will be re-generated on server restart')
-      return
-    }
-
-    log.info('client', 'bundle written to ' + bundleTargetPath)
-  })
 }
 

--- a/test/unit/client/bundle-handler-factory-test.js
+++ b/test/unit/client/bundle-handler-factory-test.js
@@ -1,0 +1,103 @@
+var proxyquire = require('proxyquire').noCallThru().noPreserveCache()
+var simple = require('simple-mock')
+var test = require('tap').test
+
+require('npmlog').level = 'error'
+
+test('bundle-handler-factory', function (group) {
+  var bundleStub
+  var bundleWriterStub
+  var npmlogStub
+  var createHandler
+
+  group.beforeEach(function (done) {
+    npmlogStub = {
+      info: simple.stub(),
+      silly: simple.stub(),
+      warn: simple.stub()
+    }
+
+    bundleStub = simple.stub()
+    bundleWriterStub = simple.stub()
+
+    createHandler = proxyquire('../../../server/plugins/client/bundle-handler-factory', {
+      './bundle': bundleStub,
+      './bundle-writer': bundleWriterStub,
+      'npmlog': npmlogStub
+    })
+
+    done()
+  })
+
+  group.test('passes clientPath, targetPath and config to bundleClient', function (t) {
+    var clientPath = '/client/path'
+    var targetPath = '/target/path'
+    var config = {}
+
+    var handler = createHandler(clientPath, targetPath, config)
+    handler()
+
+    t.is(bundleStub.callCount, 1, 'bundleClient gets called')
+    var bundleStubArgs = bundleStub.lastCall.args
+
+    t.is(bundleStubArgs[0], clientPath, 'passes clientPath as first argument')
+    t.is(bundleStubArgs[1], targetPath, 'passes targetPath as second argument')
+    t.equals(bundleStubArgs[2], config, 'passes config as third argument')
+
+    t.end()
+  })
+
+  group.test('calls clientBundleWriter and replies bundleBuffer', function (t) {
+    var targetPath = '/target/path'
+    var handler = createHandler('', targetPath, {inMemory: false})
+
+    var bundleBuffer = []
+    bundleStub.callbackWith(null, bundleBuffer, false)
+
+    handler({}, createReplyMock(function () {
+      t.is(bundleWriterStub.callCount, 1, 'writeClientBundle gets called')
+      var bundleWriterArgs = bundleWriterStub.lastCall.args
+
+      t.is(bundleWriterArgs[0], false, 'Passes update-flag to bundle-writer')
+      t.is(bundleWriterArgs[1], false, 'Passes inMemory flag to bundle-writer')
+      t.is(bundleWriterArgs[2], targetPath, 'Passes targetPath to bundle-writer')
+      t.equals(bundleWriterArgs[3], bundleBuffer, 'Passes bundleBuffer to bundle-writer')
+      t.end()
+    }))
+  })
+
+  group.test('only creates bundlePromise once', function (t) {
+    var handler = createHandler('', '', {})
+
+    var bundleBuffer = []
+    bundleStub.callbackWith(null, bundleBuffer, false)
+
+    handler({}, createReplyMock(function () {
+      handler({}, createReplyMock(function () {
+        t.is(bundleStub.callCount, 1, 'bundle only gets called once')
+        t.end()
+      }))
+    }))
+  })
+
+  group.test('throws if bundleClient fails', function (t) {
+    var handler = createHandler('', '', {})
+
+    var error = new Error('testError')
+    bundleStub.callbackWith(error)
+
+    handler({}, function (cbError) {
+      t.equals(error, cbError, 'Puts error into callback')
+      t.end()
+    })
+  })
+
+  function createReplyMock (cb) {
+    var typeStub = simple.stub().callFn(cb)
+    var bytesStub = simple.stub().returnWith({type: typeStub})
+    return simple.stub().returnWith({bytes: bytesStub})
+  }
+
+  group.end()
+})
+

--- a/test/unit/client/bundle-writer-test.js
+++ b/test/unit/client/bundle-writer-test.js
@@ -1,0 +1,73 @@
+var proxyquire = require('proxyquire').noCallThru().noPreserveCache()
+var simple = require('simple-mock')
+var test = require('tap').test
+
+require('npmlog').level = 'error'
+
+test('bundle-writer', function (group) {
+  var fsStub
+  var npmlogStub
+  var writeClientBundle
+
+  group.beforeEach(function (done) {
+    npmlogStub = {
+      info: simple.stub(),
+      silly: simple.stub(),
+      warn: simple.stub()
+    }
+
+    fsStub = {
+      writeFile: simple.stub()
+    }
+
+    writeClientBundle = proxyquire('../../../server/plugins/client/bundle-writer', {
+      'fs': fsStub,
+      'npmlog': npmlogStub
+    })
+
+    done()
+  })
+
+  group.test('logs and doesnt write bundle when noUpdate', function (t) {
+    writeClientBundle(false, false, '', [])
+
+    t.is(fsStub.writeFile.callCount, 0, 'Fs doesn`t get called')
+    t.is(npmlogStub.info.callCount, 1, 'Logs info')
+    t.end()
+  })
+
+  group.test('doesnt write when configured inMemory', function (t) {
+    writeClientBundle(true, true, '', [])
+
+    t.is(fsStub.writeFile.callCount, 0, 'fs.writeFile does not get called')
+    t.end()
+  })
+
+  group.test('writes file to targetPath when update', function (t) {
+    var targetPath = '/target/path'
+    var bufferMock = []
+    fsStub.writeFile.callbackWith(null)
+
+    writeClientBundle(true, false, targetPath, bufferMock)
+
+    t.is(fsStub.writeFile.callCount, 1, 'fs.writeFile gets called to write bundle')
+
+    var fsArgs = fsStub.writeFile.lastCall.args
+    t.equals(fsArgs[0], targetPath, 'fs.writeFile writes to the specified path')
+    t.equals(fsArgs[1], bufferMock, 'fs.writeFile writes the given bundleBuffer')
+
+    t.end()
+  })
+
+  group.test('warns when fs fails', function (t) {
+    var writeError = new Error('TestError')
+    fsStub.writeFile.callbackWith(writeError)
+
+    writeClientBundle(true, false, '', [])
+    t.is(npmlogStub.warn.callCount, 1, 'Logs a warning that fs failed ')
+    t.end()
+  })
+
+  group.end()
+})
+

--- a/test/unit/client/client-test.js
+++ b/test/unit/client/client-test.js
@@ -7,29 +7,17 @@ require('npmlog').level = 'error'
 test('client', function (group) {
   var mockServer
   var client
-  var bundleStub
-  var fsStub
-  var npmlogStub
+  var createBundleHandlerStub
 
   group.beforeEach(function (done) {
-    npmlogStub = {
-      info: simple.stub(),
-      silly: simple.stub(),
-      warn: simple.stub()
-    }
+    createBundleHandlerStub = simple.stub()
 
-    bundleStub = simple.stub()
-    fsStub = {
-      writeFile: simple.stub()
-    }
     mockServer = {
       route: simple.stub()
     }
 
     client = proxyquire('../../../server/plugins/client/index', {
-      './bundle': bundleStub,
-      'fs': fsStub,
-      'npmlog': npmlogStub
+      './bundle-handler-factory': createBundleHandlerStub
     })
 
     done()
@@ -43,105 +31,33 @@ test('client', function (group) {
     t.end()
   })
 
-  group.test('replies bundleBuffer, logs and returns when no update', function (t) {
+  group.test('passes options.config on to the handlerFactory', function (t) {
+    var configMock = {}
+    var next = simple.stub()
+    client.register(mockServer, {config: configMock}, next)
+
+    var handlerArgs = createBundleHandlerStub.lastCall.args
+
+    t.equals(handlerArgs[2], configMock)
+    t.end()
+  })
+
+  group.test('builds targetPath from config.data + "client.js"', function (t) {
+    var optionsMock = {config: {data: '/example/path'}}
+    client.register(mockServer, optionsMock, simple.stub())
+    var handlerArgs = createBundleHandlerStub.lastCall.args
+
+    t.is(handlerArgs[1], '/example/path/client.js')
+    t.end()
+  })
+
+  group.test('builds targetPath from folder ".hoodie" by default', function (t) {
     client.register(mockServer, {config: {}}, simple.stub())
 
-    var bundleBuffer = []
-    bundleStub.callbackWith(null, bundleBuffer, false)
-
-    var handler = extractHandlerFromServer()
-    handler({}, createReplyMock(function () {
-      t.is(fsStub.writeFile.callCount, 0, 'Fs doesn`t get called')
-      t.is(npmlogStub.info.callCount, 1, 'Logs info')
-      t.end()
-    }))
+    var handlerArgs = createBundleHandlerStub.lastCall.args
+    t.is(handlerArgs[1], '.hoodie/client.js')
+    t.end()
   })
-
-  group.test('only creates bundlePromise once', function (t) {
-    client.register(mockServer, {config: {}}, simple.stub())
-
-    var bundleBuffer = []
-    bundleStub.callbackWith(null, bundleBuffer, false)
-
-    var handler = extractHandlerFromServer()
-    handler({}, createReplyMock(function () {
-      handler({}, createReplyMock(function () {
-        t.is(bundleStub.callCount, 1, 'bundle only gets called once')
-        t.end()
-      }))
-    }))
-  })
-
-  group.test('replies bundleBuffer and returns when configured inMemory', function (t) {
-    client.register(mockServer, {config: { inMemory: true }}, simple.stub())
-
-    var bundleBuffer = []
-    bundleStub.callbackWith(null, bundleBuffer, true)
-
-    var handler = extractHandlerFromServer()
-    handler({}, createReplyMock(function () {
-      t.is(fsStub.writeFile.callCount, 0, 'fs.writeFile does not get called')
-      t.end()
-    }))
-  })
-
-  group.test('writes file when update', function (t) {
-    client.register(mockServer, {config: {}}, simple.stub())
-
-    var bundleBuffer = []
-    bundleStub.callbackWith(null, bundleBuffer, true)
-
-    fsStub.writeFile.callbackWith(null)
-
-    var handler = extractHandlerFromServer()
-    handler({}, createReplyMock(function () {
-      t.is(fsStub.writeFile.callCount, 1, 'fs.writeFile gets called to write bundle')
-
-      var wroteBundle = fsStub.writeFile.lastCall.args[1]
-      t.equals(wroteBundle, bundleBuffer, 'fs.writeFile writes the given bundleBuffer')
-
-      t.end()
-    }))
-  })
-
-  group.test('warns when fs fails', function (t) {
-    client.register(mockServer, {config: {}}, simple.stub())
-
-    var bundleBuffer = []
-    bundleStub.callbackWith(null, bundleBuffer, true)
-
-    var writeError = new Error('TestError')
-    fsStub.writeFile.callbackWith(writeError)
-
-    var handler = extractHandlerFromServer()
-    handler({}, createReplyMock(function () {
-      t.is(npmlogStub.warn.callCount, 1, 'Logs a warning that fs failed ')
-      t.end()
-    }))
-  })
-
-  group.test('throws if bundleClient fails', function (t) {
-    client.register(mockServer, {config: {}}, simple.stub())
-
-    var error = new Error('testError')
-    bundleStub.callbackWith(error)
-
-    var handler = extractHandlerFromServer()
-    handler({}, function (cbError) {
-      t.equals(error, cbError, 'Puts error into callback')
-      t.end()
-    })
-  })
-
-  function extractHandlerFromServer () {
-    return mockServer.route.lastCall.arg[0].handler
-  }
-
-  function createReplyMock (cb) {
-    var typeStub = simple.stub().callFn(cb)
-    var bytesStub = simple.stub().returnWith({type: typeStub})
-    return simple.stub().returnWith({bytes: bytesStub})
-  }
 
   group.end()
 })


### PR DESCRIPTION
PR for #594 .

As stated I extracted a factory functions and added several more tests for the paths given to the `bundleClient` and `fs` functions.

I also added a first test for the paths that get built within the `client/index.js`. I realized quickly that thre is made use of `require.resolve` - which is not mockable and therefore the built path is not testable right now.

`require.resolve` is also used within the `server/public.js` file. I think it could be a good idea to take all those `require.resolve` calls into an own separate module like `modulePathResolver` that could look like this:

```
var path = require('path')
var modulePathResolver = {
   getClientPath() : function () {
      return require.resolve('@hoodie/client/package.json')
  }
  getPublicPath : function () {
    return path.join(require.resolve('../../package.json'), '..', 'public')
  }
  getAccountPublicPath : function () {
    return path.join(require.resolve('@hoodie/account/package.json'), '..', 'public')
  }
  // ... and so on for all modulePaths
}
```

@gr2m What do you think about that? Should I raise another issue for it?
