### PR TITLE
App-specific client/server plugins 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,43 @@ option                    | default      | description
 **account**               | `{}`         | [Hoodie Account Server](https://github.com/hoodiehq/hoodie-account-server/tree/master/plugin#options) options. `account.admins`, `account.secret` and `account.usersDb` are set based on `db` option above.
 **store**                 | `{}`         | [Hoodie Store Server](https://github.com/hoodiehq/hoodie-store-server#options) options. `store.couchdb`, `store.PouchDB` are set based on `db` option above. `store.hooks.onPreAuth` is set to bind user authentication for Hoodie Account to Hoodie Store.
 
+## Extending Hoodie for your app
+
+You can add custom behavior to your hoodie-based application in a few ways:
+
+1. The server-side functionality can be extended by adding a module constructed as a [hapi plugin](http://hapijs.com/tutorials/plugins)
+ to the path `hoodie/server`. E.g:
+ 
+```js
+exports.register = function (server, options, next) {
+  // server-relevant code here
+  next();
+}
+
+exports.register.attributes = {
+  'name': 'my-app'
+}
+```
+ 
+2. The client-side functionality can be extended by adding a module that can be interpreted as a [hoodie plugin](https://github.com/hoodiehq/hoodie-client#hoodieplugin)
+ to the path `hoodie/client`, which by default will be built into the client.js package by browserify. 
+ 
+```js
+module.exports = {
+  demonstratePlugin: function () { // will be attached as hoodie.demonstratePlugin()
+    // client-relevant code here
+  }
+}
+```
+
+Both of the above paths will be imported as if Node modules, so the path to the entry file for each module can be
+`hoodie/{server,client}.js` or `hoodie/{server,client}/index.js`.
+   
+Note that for now only the file modification time of the entry file of the client module is used to determine the
+freshness of the client bundle and therefore whether it should be rebuilt on the first request after a server restart.
+If your client code stretches to many files, you may need to update the `mtime` of the client entry file by using
+`touch` or a similar method before restarting your server to ensure that the client bundle is rebuilt.
+   
 ## Testing
 
 Local setup

--- a/cli/parse-options.js
+++ b/cli/parse-options.js
@@ -25,7 +25,8 @@ function parseOptions (options) {
       data: options.data,
       public: options.public
     },
-    db: {}
+    db: {},
+    inMemory: Boolean(options.inMemory)
   }
 
   log.level = config.loglevel
@@ -36,9 +37,6 @@ function parseOptions (options) {
 
   if (options.dbUrl) {
     config.db.url = options.dbUrl
-  }
-  if (options.inMemory) {
-    config.inMemory = true
   }
 
   return config

--- a/server/index.js
+++ b/server/index.js
@@ -16,14 +16,12 @@ var registerPlugins = require('./plugins')
 
 function register (server, options, next) {
   options = _.cloneDeep(options)
-  if (!options.db) {
-    options.db = {}
-  }
-  if (!options.paths) {
-    options.paths = {
+  _.defaultsDeep(options, {
+    db: {},
+    paths: {
       public: 'public'
     }
-  }
+  })
 
   // mapreduce is required for `db.query()`
   PouchDB.plugin(require('pouchdb-mapreduce'))

--- a/server/plugins/public.js
+++ b/server/plugins/public.js
@@ -8,7 +8,7 @@ var fs = require('fs')
 var path = require('path')
 
 function register (server, options, next) {
-  var publicFolder = options.config.paths.public || 'public'
+  var publicFolder = options.config.paths.public
   var app = path.join(publicFolder, 'index.html')
   var hoodieVersion
   try {

--- a/server/plugins/resolver.js
+++ b/server/plugins/resolver.js
@@ -1,0 +1,1 @@
+module.exports = require.resolve

--- a/test/fixture/app-dir-with-server/hoodie/server.js
+++ b/test/fixture/app-dir-with-server/hoodie/server.js
@@ -1,0 +1,5 @@
+module.exports = register
+
+function register (server, options, next) {
+  return next()
+}

--- a/test/integration/server-test.js
+++ b/test/integration/server-test.js
@@ -1,5 +1,6 @@
 var simple = require('simple-mock')
 var test = require('tap').test
+var path = require('path')
 
 var hapiPlugin = require('../../server')
 var serverMock = {
@@ -82,3 +83,21 @@ test('error on register is passed to callback', function (t) {
   })
 })
 
+test('application root with valid server module', function (t) {
+  var options = {
+    paths: {
+      public: 'public'
+    }
+  }
+  var savedPath = process.cwd()
+  t.tearDown(function () {
+    process.chdir(savedPath)
+  })
+
+  process.chdir(path.resolve(__dirname, '../fixture/app-dir-with-server/'))
+
+  hapiPlugin.register(serverMock, options, function (error, server, options) {
+    t.error(error)
+    t.end()
+  })
+})

--- a/test/unit/cli/options-test.js
+++ b/test/unit/cli/options-test.js
@@ -102,13 +102,14 @@ test('config', function (group) {
     t.end()
   })
 
-  group.test('public option', function (t) {
+  group.test('path options', function (t) {
     var fallbackValue = 'fallback-public'
     mockWebrootLocator.returnWith(fallbackValue)
 
-    var options = getCliOptions(yargsApi)
+    var projectPath = 'project-path'
+    var options = getCliOptions(projectPath)
 
-    t.equal(options.public, fallbackValue, 'uses the value returned from webroot locator')
+    t.equal(options.public, fallbackValue, 'public option uses the value returned from webroot locator')
     t.end()
   })
 

--- a/test/unit/cli/parse-options-test.js
+++ b/test/unit/cli/parse-options-test.js
@@ -25,57 +25,33 @@ var parseOptions = proxyquire('../../../cli/parse-options', {
 })
 
 test('parse options', function (group) {
-  group.test('defaults', function (t) {
-    var config = parseOptions({
-      public: 'public',
-      data: 'data'
-    })
+  group.test('unset keys', function (t) {
+    var config = parseOptions({})
 
-    t.is(config.url, undefined, 'does not set config.url by default')
-    t.is(config.paths.data, 'data', 'sets config.paths.data from defaults')
-    t.is(config.paths.public, 'public', 'sets config.public.data from defaults')
+    t.notOk(config.hasOwnProperty('url'), 'does not set config.url by default')
+    t.notOk(config.db.hasOwnProperty('url'), 'does not set config.db.url by default')
+    t.is(config.inMemory, false, 'sets config.inMemory to false by default')
 
     t.end()
   })
 
-  group.test('overwrites', function (t) {
+  group.test('wiring', function (t) {
     var config = parseOptions({
       data: 'options.data',
       public: 'options.public',
-      url: 'options.url'
+      url: 'options.url',
+      dbUrl: 'http://foo:bar@baz.com',
+      inMemory: 'aNonNullString'
     })
 
     t.is(config.paths.data, 'options.data', 'uses data option as data path')
     t.is(config.url, 'options.url', 'sets config.url from options.url')
     t.is(config.paths.public, 'options.public', 'uses public option as public path')
-
-    t.end()
-  })
-
-  group.test('dbUrl', function (t) {
-    var config = parseOptions({
-      public: 'public',
-      data: 'data',
-      dbUrl: 'http://foo:bar@baz.com'
-    })
-
-    t.is(config.db.url, 'http://foo:bar@baz.com', 'Sets config.db.url')
-
-    t.end()
-  })
-
-  group.test('inMemory', function (t) {
-    var config = parseOptions({
-      public: 'public',
-      data: 'data',
-      inMemory: true
-    })
-
-    t.is(config.inMemory, true, 'Sets config.inMemory to true')
+    t.is(config.db.url, 'http://foo:bar@baz.com', 'sets config.db.url from options.dbUrl')
+    t.is(config.inMemory, true, 'Sets config.inMemory to boolean equivalent of options.inMemory')
 
     t.end()
   })
 
   group.end()
 })
-

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -1,6 +1,7 @@
 var proxyquire = require('proxyquire').noCallThru()
 var simple = require('simple-mock')
 var test = require('tap').test
+var pathResolve = require('path').resolve
 
 require('npmlog').level = 'error'
 
@@ -149,6 +150,163 @@ test('bundle client', function (group) {
       t.equal(error, testError)
       t.end()
     })
+  })
+
+  group.test('app\'s root directory is specified', function (t) {
+    var bundleMock = simple.stub().callbackWith(null, new Buffer('hoodie client content'))
+    var requireMock = simple.stub()
+    var unspecifiedError = new Error('UNSPECIFIED_ERROR')
+    var savedPath = process.cwd()
+    var resolverMock = simple.stub().callFn(function (path) {
+      if (path === pathResolve(__dirname, '../fixture/app-dir-with-server/hoodie/client')) {
+        return pathResolve(__dirname, '../fixture/app-dir-with-server/hoodie/client.js')
+      }
+
+      if (path === pathResolve(__dirname, '../fixture/hoodie/client')) {
+        throw unspecifiedError
+      }
+
+      var err = new Error('Not Found', 'MODULE_NOT_FOUND')
+      err.code = 'MODULE_NOT_FOUND'
+      throw err
+    })
+
+    var streamStub = {}
+    var currentDate = Date.now()
+    var oneHourAgo = new Date(currentDate.valueOf() - (1000 * 60 * 60))
+    var twoHoursAgo = new Date(currentDate.valueOf() - (2000 * 60 * 60))
+    var fsMock = {
+      readFile: undefined,
+      stat: undefined
+    }
+    var bundleClient = proxyquire('../../server/plugins/client/bundle', {
+      browserify: function () {
+        return {
+          bundle: bundleMock,
+          require: requireMock
+        }
+      },
+      '../resolver': resolverMock,
+      fs: fsMock,
+      stream: {
+        Readable: simple.stub().returnWith(streamStub)
+      }
+    })
+
+    t.tearDown(function () {
+      process.chdir(savedPath)
+    })
+
+    t.test('client module exists and is newer', function (t) {
+      streamStub.push = simple.stub()
+      fsMock.stat = simple.stub().callFn(function (path, callback) {
+        if (path === pathResolve(__dirname, '../fixture/app-dir-with-server/hoodie/client.js')) {
+          return callback(null, {mtime: currentDate})
+        }
+        if (path === 'client.js') {
+          return callback(null, {mtime: twoHoursAgo})
+        }
+
+        return callback(null, {mtime: oneHourAgo})
+      })
+      fsMock.readFile = simple.stub()
+      process.chdir(pathResolve(__dirname, '../fixture/app-dir-with-server/'))
+      bundleClient('client.js', 'bundle.js', {
+        url: 'https://myapp.com'
+      }, function (error, buffer) {
+        t.error(error)
+
+        t.is(fsMock.stat.callCount, 3, 'stat called thrice')
+        t.is(fsMock.readFile.callCount, 0, 'readFile not called')
+
+        var expected = 'var Hoodie = require("@hoodie/client")\n' +
+          'var options = {\n' +
+          '  url: "https://myapp.com",\n' +
+          '  PouchDB: require("pouchdb-browser")\n' +
+          '}\n' +
+          'module.exports = new Hoodie(options)\n' +
+          '  .plugin(require("' + pathResolve(__dirname, '../fixture/app-dir-with-server/hoodie/client') + '"))\n'
+        t.is(streamStub.push.calls[0].arg, expected)
+
+        t.end()
+      })
+    })
+
+    t.test('client module exists and is older', function (t) {
+      streamStub.push = simple.stub()
+      fsMock.stat = simple.stub().callFn(function (path, callback) {
+        if (path === pathResolve(__dirname, '../fixture/app-dir-with-server/hoodie/client.js')) {
+          return callback(null, {mtime: oneHourAgo})
+        }
+        if (path === 'client.js') {
+          return callback(null, {mtime: twoHoursAgo})
+        }
+
+        return callback(null, {mtime: currentDate})
+      })
+      fsMock.readFile = simple.stub().callbackWith(null, new Buffer('bundle content'))
+      process.chdir(pathResolve(__dirname, '../fixture/app-dir-with-server/'))
+      bundleClient('client.js', 'bundle.js', {
+        url: 'https://myapp.com'
+      }, function (error, buffer) {
+        t.error(error)
+
+        t.is(fsMock.stat.callCount, 3, 'stat called thrice')
+        t.is(fsMock.readFile.callCount, 1, 'readFile called once')
+        t.is(fsMock.readFile.lastCall.arg, 'bundle.js', 'read bundle')
+
+        t.end()
+      })
+    })
+
+    t.test('client module doesn\'t exist', function (t) {
+      streamStub.push = simple.stub()
+      fsMock.stat = simple.stub().callFn(function (path, callback) {
+        if (path === pathResolve(__dirname, '../fixture/app-dir-without-server/hoodie/client.js')) {
+          throw new Error('Boom')
+        }
+        if (path === 'client.js') {
+          return callback(null, {mtime: twoHoursAgo})
+        }
+
+        callback(new Error('Boom'))
+      })
+      fsMock.readFile = simple.stub()
+      process.chdir(pathResolve(__dirname, '../fixture/app-dir-without-server/'))
+      bundleClient('client.js', 'bundle.js', {
+        url: 'https://myapp.com'
+      }, function (error, buffer) {
+        t.error(error)
+
+        var expected = 'var Hoodie = require("@hoodie/client")\n' +
+          'var options = {\n' +
+          '  url: "https://myapp.com",\n' +
+          '  PouchDB: require("pouchdb-browser")\n' +
+          '}\n' +
+          'module.exports = new Hoodie(options)\n'
+        t.is(fsMock.stat.callCount, 2, 'stat called twice')
+        t.is(fsMock.readFile.callCount, 0, 'readFile not called')
+        t.is(streamStub.push.calls[0].arg, expected)
+
+        t.end()
+      })
+    })
+
+    t.test('require.resolve rethrows other errors', function (t) {
+      streamStub.push = simple.stub()
+      fsMock.readFile = simple.stub()
+      process.chdir(pathResolve(__dirname, '../fixture/'))
+      t.throws(function () {
+        bundleClient('client.js', 'bundle.js', {
+          url: 'https://myapp.com'
+        }, function () {
+          t.fail()
+        })
+      }, unspecifiedError)
+      t.end()
+    })
+
+    t.end()
   })
 
   group.end()

--- a/test/unit/server/loader-test.js
+++ b/test/unit/server/loader-test.js
@@ -1,0 +1,29 @@
+var simple = require('simple-mock')
+var test = require('tap').test
+var proxyquire = require('proxyquire').noCallThru()
+
+var mockResolver = simple.stub()
+var loader = proxyquire('../../../server/plugins', {
+  './resolver': mockResolver
+})
+var serverMock = {
+  register: simple.stub().callbackWith(null)
+}
+
+test('when require.resolve errors', function (t) {
+  var options = {
+    paths: {
+      public: 'public'
+    }
+  }
+
+  var error = new Error('Unspecified error')
+  mockResolver.throwWith(error)
+
+  t.throws(function () {
+    loader(serverMock, options, function () {
+      t.fail('the error has not been rethrown')
+    })
+  }, error, 'the error is rethrown')
+  t.end()
+})


### PR DESCRIPTION
closes hoodiehq/discussion#98

* [x] If detected, the code at `hoodie/client` relative to the app root is to be bundled alongside hoodie's client code
* [x] If detected, the code at `hoodie/server` relative to the app root is to be loaded as a hapi plugin
* [x] Check modified time of plugins to build bundle as well as hoodie's internal client code
* [x] Update `README.md` to document hoodie's consumption of application-defined server/client code
* [x] (After merging) Open issue to document approach to better handling updated app client code [as described here](#discussion_r92874443) ▶️ https://github.com/hoodiehq/hoodie/issues/655