### PR TITLE
docs: Fixed .hoodierc example JSON syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ option                    | default       | description
 
 Hoodie CLI is using [rc](https://www.npmjs.com/package/rc) for configuration, so the same options can be set with environment variables and config files. Environment variables are prefixed with `hoodie_`. Examples: `hoodie_port=8090` or `hoodie_inMemory=true`. Configuration files can be in INI or JSON format and [can be placed at different locations](https://www.npmjs.com/package/rc#standards). Most commonly you would place a `.hoodierc` file in your app’s directory, and it can look like this
 
-```js
+```json
 {
-  port: 8090,
-  inMemory: true
+  "port": 8090,
+  "inMemory": true
 }
 ```
 


### PR DESCRIPTION
Currently, when you copy the `.hoodierc` example from README, you will get a JSON parse error.
I fixed the JSON syntax and changed the code syntax highlighting to JSON also.