### PR TITLE
feat: Modified setup.js not to overide "start" script in package.json

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -20,7 +20,7 @@ if (saveRequested) {
     log.info('setup', 'start script already set to "' + packageJson.scripts[ 'start' ] +
     ', you can start hoodie with "npm run start-hoodie" instead')
 
-    packageJson.scripts[ 'start-hoodie' ] = packageJson.scripts[ 'start' ]
+    packageJson.scripts[ 'start-hoodie' ] = 'hoodie'
   } else {
     packageJson.scripts[ 'start' ] = 'hoodie'
   }

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -15,7 +15,15 @@ if (saveRequested) {
   var packageJson = require(path.join(pathToAppRoot, 'package.json'))
 
   packageJson.scripts = packageJson.scripts || {}
-  packageJson.scripts[ 'start' ] = 'hoodie'
+
+  if (packageJson.scripts[ 'start' ]) {
+    log.info('setup', 'start script already set to "' + packageJson.scripts[ 'start' ] +
+    ', you can start hoodie with "npm run start-hoodie" instead')
+
+    packageJson.scripts[ 'start-hoodie' ] = packageJson.script[ 'start' ]
+  } else {
+    packageJson.script[ 'start' ] = 'hoodie'
+  }
 
   var newPackageJson = JSON.stringify(packageJson, null, 2)
 

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -20,9 +20,9 @@ if (saveRequested) {
     log.info('setup', 'start script already set to "' + packageJson.scripts[ 'start' ] +
     ', you can start hoodie with "npm run start-hoodie" instead')
 
-    packageJson.scripts[ 'start-hoodie' ] = packageJson.script[ 'start' ]
+    packageJson.scripts[ 'start-hoodie' ] = packageJson.scripts[ 'start' ]
   } else {
-    packageJson.script[ 'start' ] = 'hoodie'
+    packageJson.scripts[ 'start' ] = 'hoodie'
   }
 
   var newPackageJson = JSON.stringify(packageJson, null, 2)


### PR DESCRIPTION
Added a condition to check if packageJson.scripts["start"] has a value and blocked to override this value. Instead, overriding the "start" value, Added a statement to store this value to "start-hoodie" script in package.json