### PR TITLE
feat: Default url option to location.origin in bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@hoodie/account": "^2.0.0",
     "@hoodie/admin": "^1.0.1",
-    "@hoodie/client": "^6.0.0",
+    "@hoodie/client": "^7.0.0",
     "@hoodie/server": "^21.1.0",
     "@hoodie/store": "^1.0.1",
     "async": "^2.0.0",

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -65,9 +65,19 @@ function buildBundle (config, hoodieClientPath, callback) {
       return callback(error)
     }
 
-    var options = config.url ? '{url: "' + config.url + '"}' : ''
-    var initBuffer = Buffer('\n\nhoodie = new Hoodie(' + options + ')')
+    var initScript = '\n\n'
+    if (config.url) {
+      initScript += 'var hoodieOptions = {url: "' + config.url + '"}\n'
+    }
+    else {
+      initScript += 'var hoodieOptions = {}\n'
+      initScript += 'if (location && location.origin) {\n'
+      initScript += '  hoodieOptions.url = location.origin\n'
+      initScript += '}\n\n'
+    }
+    initScript += 'hoodie = new Hoodie(hoodieOptions)'
 
+    var initBuffer = Buffer(initScript)
     callback(null, Buffer.concat([buffer, initBuffer]))
   })
 

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -51,7 +51,15 @@ test('bundle client', function (group) {
 
       t.is(requireMock.lastCall.arg, 'client.js', 'require client')
       t.is(bundleMock.callCount, 1, 'bundle called once')
-      t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie()')
+
+      var expectation = 'hoodie client content\n\n'
+      expectation += 'var hoodieOptions = {}\n'
+      expectation += 'if (location && location.origin) {\n'
+      expectation += '  hoodieOptions.url = location.origin\n'
+      expectation += '}\n\n'
+      expectation += 'hoodie = new Hoodie(hoodieOptions)'
+
+      t.is(buffer.toString(), expectation)
 
       t.end()
     })
@@ -84,7 +92,10 @@ test('bundle client', function (group) {
     }, function (error, buffer) {
       t.error(error)
 
-      t.is(buffer.toString(), 'hoodie client content\n\nhoodie = new Hoodie({url: "https://myapp.com"})')
+      var expectation = 'hoodie client content\n\n'
+      expectation += 'var hoodieOptions = {url: "https://myapp.com"}\n'
+      expectation += 'hoodie = new Hoodie(hoodieOptions)'
+      t.is(buffer.toString(), expectation)
 
       t.end()
     })


### PR DESCRIPTION
Closes hoodiehq/hoodie-client#105. Closes https://github.com/hoodiehq/hoodie/pull/649

This belongs to hoodiehq/hoodie-client#109. The issue required changes in both repositories.