### PR TITLE
fix 404s

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
         <li> Setup your asset folders and create your .css and .js files.</li>
         <li> You’ll need to restart the Hoodie server so it servers assets from your app’s <code>public</code> folder</li>
       </ol>
-      <p>If you want to learn more, check out the <a href="http://docs.hood.ie/camp/"> documentation (work-in-progress).</a></p>
+      <p>If you want to learn more, check out the <a href="http://docs.hood.ie"> documentation (work-in-progress).</a></p>
       <p>Happy coding! 🐶</p>
     </div>
 


### PR DESCRIPTION
For the API 404s, not sure if I did it right.

for example if you go here: https://github.com/quangv/hoodie/blob/master/docs/api/index.rst it's still 404, it'll be nice if the links work on both http://docs.hood.ie/ && github.

