### PR TITLE
Add travis script to ensure quick-start functionality works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - 4
 before_script:
   - npm prune
+  - bin/quick-start-test.sh
 after_success:
   - npm run semantic-release
   - npm run coverage

--- a/bin/quick-start-test.sh
+++ b/bin/quick-start-test.sh
@@ -2,7 +2,7 @@
 HOODIE_FOLDER=$(pwd)
 TEMP_ROOT=$(mktemp -d)
 pushd $TEMP_ROOT
-trap "{ popd; rm -rf $TEMP_ROOT; exit 255; }" EXIT
+trap "{ CODE=$?; popd; rm -rf $TEMP_ROOT; exit $CODE; }" EXIT
 
 ## docs/guides/quickstart.rst:41
 

--- a/bin/quick-start-test.sh
+++ b/bin/quick-start-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+HOODIE_FOLDER=$(pwd)
+TEMP_ROOT=$(mktemp -d)
+pushd $TEMP_ROOT
+trap "{ popd; rm -rf $TEMP_ROOT; exit 255; }" EXIT
+
+## docs/guides/quickstart.rst:41
+
+npm init -y
+
+## docs/guides/quickstart.rst:47
+
+npm install $HOODIE_FOLDER --save
+
+## docs/guides/quickstart.rst:72
+
+npm start & HOODIE_PROCESS=$!
+
+## Give the process a generous sixty seconds to start
+
+RETRIES=60
+while [ "$RETRIES" -gt 0 ] ; do
+  sleep 1
+  kill -0 $HOODIE_PROCESS 2&>1 > /dev/null || { echo "Hoodie exited prematurely"; wait $HOODIE_PROCESS ; exit $? ; }
+  curl -I http://localhost:8080/hoodie/client.js > /dev/null && break
+  let RETRIES=RETRIES-1
+done
+
+kill $HOODIE_PROCESS
+
+[ $RETRIES -le 0 ] && { echo "Timed out waiting for hoodie to start"; exit 1 ; }
+
+exit 0;


### PR DESCRIPTION
This is intended to demonstrate failing the travis build when something has broken the quick-start instructions.

Can be treated as a work in progress and merged when a fix to the issue that is currently causing errors - hoodiehq/hoodie-server#529 - has been merged.