### PR TITLE
requests to /hoodie/*/api currently return 404s

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -73,7 +73,22 @@ function register (server, options, next) {
         return next(error)
       }
 
-      next(null, server, options)
+      // we register a router handler for /hoodie/* which must be registered
+      // after all other plugins, otherwise routes like /hoodie/account/api/*
+      // will be handled by the public route handler
+      server.register({
+        register: require('./plugins/public'),
+        options: {
+          config: options
+        }
+      }, function (error) {
+        /* istanbul ignore next */
+        if (error) {
+          return next(error)
+        }
+
+        next(null, server, options)
+      })
     })
   })
 }

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -91,7 +91,7 @@ function buildBundle (config, plugins, callback) {
   hoodieBundleSource += '  PouchDB: require("pouchdb-browser")\n'
   hoodieBundleSource += '}\n'
   hoodieBundleSource += 'module.exports = new Hoodie(options)\n'
-  plugins.forEach(function(pluginPath) {
+  plugins.forEach(function (pluginPath) {
     hoodieBundleSource += '  .plugin(require("' + pluginPath + '"))\n'
   })
 

--- a/server/plugins/index.js
+++ b/server/plugins/index.js
@@ -27,8 +27,7 @@ function registerPlugins (server, config, callback) {
   var localPlugins = [
     './client',
     './logger',
-    './maybe-force-gzip',
-    './public'
+    './maybe-force-gzip'
   ]
     .concat(
   [


### PR DESCRIPTION
closes #669. This will fix https://github.com/hoodiehq/hoodie-app-tracker/pull/122. I’m so sorry for the trouble y’all 