### PR TITLE
don’t stop the logging

### DIFF
--- a/server/plugins/good-hoodie.js
+++ b/server/plugins/good-hoodie.js
@@ -51,7 +51,7 @@ function transform (data, enc, next) {
   }
 
   log.silly(data.event, data)
-  next(null, data)
+  next(null)
 }
 
 function findLogLevel (levels, tags) {

--- a/test/unit/server/logger-test.js
+++ b/test/unit/server/logger-test.js
@@ -155,7 +155,7 @@ test('logger', function (group) {
     logger._transform(eventMock, 'utf8', transformCallback)
 
     t.equals(transformCallback.callCount, 1, 'callback is called')
-    t.equals(transformCallback.lastCall.args[1], eventMock, 'data is passed through transform')
+    t.equals(transformCallback.lastCall.args[1], undefined, 'nothing is passed through transform')
 
     t.end()
   })


### PR DESCRIPTION
I run into a problem where logging would simply stop working after a moment. I don’t understand exactly why, but this change fixes it