### PR TITLE
client-test.js: windows separator slash fix, path separator for every OS via path.join

### DIFF
--- a/test/unit/client/client-test.js
+++ b/test/unit/client/client-test.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 var simple = require('simple-mock')
 var test = require('tap').test
@@ -47,7 +48,7 @@ test('client', function (group) {
     client.register(mockServer, optionsMock, simple.stub())
     var handlerArgs = createBundleHandlerStub.lastCall.args
 
-    t.is(handlerArgs[1], '/example/path/client.js')
+    t.is(handlerArgs[1], path.sep + path.join('example', 'path', 'client.js'))
     t.end()
   })
 
@@ -55,7 +56,7 @@ test('client', function (group) {
     client.register(mockServer, {config: {}}, simple.stub())
 
     var handlerArgs = createBundleHandlerStub.lastCall.args
-    t.is(handlerArgs[1], '.hoodie/client.js')
+    t.is(handlerArgs[1], path.join('.hoodie', 'client.js'))
     t.end()
   })
 


### PR DESCRIPTION
A tiny fix that resolves #700, meaning that it's fixing path separators for different OS in test `test/unit/client/client-test.js` (it occured a problem in windows OS).