### PR TITLE
Fix link to triaging process document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ same license as that used by the project.
 
 ## Triagers
 
-There is a [defined process](TRIAGING.md) to manage issues, because this helps to speed up releases and minimizes user pain.
+There is a [defined process](docs/developers/TRIAGING.rst) to manage issues, because this helps to speed up releases and minimizes user pain.
 Triaging is a great way to contribute to Hoodie without having to write code.
 If you are interested, please [leave a comment here](https://github.com/hoodiehq/discussion/issues/50) asking to join the triaging team.
 


### PR DESCRIPTION
The link was broken. This fixes it.