### PR TITLE
[DO NOT MERGE] wip: de-es2015-ify #711

### DIFF
--- a/cli/options.js
+++ b/cli/options.js
@@ -108,7 +108,7 @@ function getCliOptions (projectPath) {
     log.warn('The use of --bindAddress is deprecated. Use the --address option instead.')
     options.address = options.bindAddress
   }
-
+  options.plugins = defaults.plugins
   options.public = webrootLocator(options.public)
 
   // rc & yargs are setting keys we are not interested in, like in-memory or _

--- a/cli/options.js
+++ b/cli/options.js
@@ -19,7 +19,6 @@ function getCliOptions (projectPath) {
   // 2. App defaults
   // 3. rc (https://www.npmjs.com/package/rc) – note we don’t read CLI through rc
   var defaults = rc('hoodie', hoodieDefaults, appDefaults)
-
   var options = yargs
     .options({
       loglevel: {
@@ -108,7 +107,13 @@ function getCliOptions (projectPath) {
     log.warn('The use of --bindAddress is deprecated. Use the --address option instead.')
     options.address = options.bindAddress
   }
+
   options.plugins = defaults.plugins
+  // include any plugin options
+  if (defaults.pluginOptions && Object.keys(defaults.pluginOptions).length) {
+    options.pluginOptions = defaults.pluginOptions
+  }
+
   options.public = webrootLocator(options.public)
 
   // rc & yargs are setting keys we are not interested in, like in-memory or _

--- a/cli/parse-options.js
+++ b/cli/parse-options.js
@@ -31,6 +31,7 @@ function parseOptions (options) {
       data: options.data,
       public: options.public
     },
+    plugins: options.plugins,
     inMemory: Boolean(options.inMemory)
   }
 

--- a/cli/parse-options.js
+++ b/cli/parse-options.js
@@ -66,5 +66,9 @@ function parseOptions (options) {
   }
   config.PouchDB = PouchDB.defaults(dbOptions)
 
+  if (options.pluginOptions) {
+    config.pluginOptions = options.pluginOptions
+  }
+
   return config
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ module.exports.register.attributes = {
   name: 'hoodie'
 }
 
+
 var corsHeaders = require('hapi-cors-headers')
 var hoodieServer = require('@hoodie/server').register
 var _ = require('lodash')

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ function register (server, options, next) {
     if (error) {
       return next(error)
     }
+
     registerPlugins(server, options, function (error) {
       if (error) {
         return next(error)

--- a/server/plugins/client/bundle-handler-factory.js
+++ b/server/plugins/client/bundle-handler-factory.js
@@ -23,7 +23,6 @@ function createBundleHandler (hoodieClientPath, bundleTargetPath, bundleConfig) 
         })
       })
     }
-
     bundlePromise.then(function (buffer) {
       reply(buffer).bytes(buffer.length).type('application/javascript')
     }).catch(reply)

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -28,10 +28,14 @@ function checkModule (module) {
  * and avoiding unneeded bundling with browserify saves a significant time.
  */
 function bundleClient (hoodieClientPath, bundleTargetPath, config, callback) {
+  config.plugins = config.plugins || []
   var plugins = [
     path.resolve('hoodie/client'),
-    ...(config.plugins.map(i => `${i}/hoodie/client`))
-  ].filter(checkModule)
+  ].concat(config.plugins.map(function (i) {
+     return i + '/hoodie/client'
+   }))
+  .filter(checkModule)
+
   var getPluginsModifiedTimes = plugins.map(function (pluginPath) {
     return getModifiedTime.bind(null, requireResolve(pluginPath))
   })

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -29,7 +29,8 @@ function checkModule (module) {
  */
 function bundleClient (hoodieClientPath, bundleTargetPath, config, callback) {
   var plugins = [
-    path.resolve('hoodie/client')
+    path.resolve('hoodie/client'),
+    ...(config.plugins.map(i => `${i}/hoodie/client`))
   ].filter(checkModule)
   var getPluginsModifiedTimes = plugins.map(function (pluginPath) {
     return getModifiedTime.bind(null, requireResolve(pluginPath))

--- a/server/plugins/index.js
+++ b/server/plugins/index.js
@@ -17,9 +17,9 @@ function checkModule (module) {
 }
 
 function registerPlugins (server, config, callback) {
-  var options = {
-    config: config
-  }
+
+  const options = Object.assign({ config }, config.pluginOptions)
+
   var hapiPlugins = [
     require('inert')
   ]

--- a/server/plugins/index.js
+++ b/server/plugins/index.js
@@ -32,7 +32,8 @@ function registerPlugins (server, config, callback) {
   ]
     .concat(
   [
-    path.resolve('hoodie/server')
+    path.resolve('hoodie/server'),
+    ...(config.plugins.map(i => `${i}/hoodie/server`))
   ]
     .filter(checkModule)
     )

--- a/server/plugins/index.js
+++ b/server/plugins/index.js
@@ -18,12 +18,16 @@ function checkModule (module) {
 
 function registerPlugins (server, config, callback) {
 
-  const options = Object.assign({ config }, config.pluginOptions)
+  // TODO: port away from Objec.assign (or require Node 6.0.0+ for Hoodie)
+  var options = Object.assign({ config: config }, config.pluginOptions)
 
   var hapiPlugins = [
     require('inert')
   ]
-
+  config.plugins = config.plugins || [] // doesn’t work, config.plugins is {} here
+  if (Object.keys(config.plugins).length === 0) {
+    config.plugins = [] // workaround for above issue
+  }
   var localPlugins = [
     './client',
     './logger',
@@ -33,8 +37,8 @@ function registerPlugins (server, config, callback) {
     .concat(
   [
     path.resolve('hoodie/server'),
-    ...(config.plugins.map(i => `${i}/hoodie/server`))
   ]
+    .concat(config.plugins.map(function (i) { i + '/hoodie/server' }))
     .filter(checkModule)
     )
     .map(function (register) {

--- a/server/plugins/public.js
+++ b/server/plugins/public.js
@@ -4,13 +4,14 @@ module.exports.register.attributes = {
   dependencies: 'inert'
 }
 
-const path = require('path')
-const requireResolve = require('./resolver')
+var path = require('path')
+var requireResolve = require('./resolver')
 var createReadStream = require('fs').createReadStream
 var pathJoin = path.join
 
 function register (server, options, next) {
-  const { paths, plugins } = options.config
+  var paths = options.config.path
+  var plugins = options.config.plugins
   var publicFolder = paths.public
 
   var hoodieVersion
@@ -22,7 +23,7 @@ function register (server, options, next) {
 
   var hoodiePublicPath = pathJoin(requireResolve('../../package.json'), '..', 'public')
   var adminPublicPath = pathJoin(requireResolve('@hoodie/admin/package.json'), '..', 'dist')
-  const routes = [{
+  var routes = [{
     method: 'GET',
     path: '/{p*}',
     handler: {
@@ -65,11 +66,11 @@ function register (server, options, next) {
   }]
 
   // add plugin routes
-  plugins.forEach(i => {
-    let module
+  plugins.forEach(function (i) {
+    var module
     // check if module directory exists
     try {
-      module = requireResolve(`${i}/package.json`)
+      module = requireResolve(i + '/package.json')
     } catch (err) {
       if (err.code !== 'MODULE_NOT_FOUND') {
         throw err
@@ -79,7 +80,7 @@ function register (server, options, next) {
     if (module) {
       routes.push({
         method: 'GET',
-        path: `/hoodie/${i}/{p*}`,
+        path: '/hoodie/ ' + i + '/{p*}',
         handler: {
           directory: {
             path: pathJoin(path.dirname(require.resolve(module)),  'hoodie', 'public'),


### PR DESCRIPTION
PR against #711 

I started porting the ES2015 code to ES5, with one `Object.assign()` left with a note: https://github.com/hoodiehq/hoodie/pull/745/files#diff-c9bb31bbcc08d333b150cdd7e696ad9eR21

Also, I found that the code assumes plugins being defined in `package.json` and getting “map is not a function on config.plugins` when non are defined. I added hot fixes for those, just to see if I get the rest right, that should be cleaned up: https://github.com/hoodiehq/hoodie/pull/745/files#diff-c9bb31bbcc08d333b150cdd7e696ad9eR29 and https://github.com/hoodiehq/hoodie/pull/745/files#diff-9f4a3658710e8d0ddf5ec999ae25f2adR31