### PR TITLE
fix local test coverage on Macs

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "start": "./bin/start.js",
     "pretest": "standard",
-    "test": "nyc tap --no-cov ./test/{unit,integration}/**/*-test.js",
+    "test": "nyc tap --no-cov './test/{unit,integration}/**/*-test.js'",
     "postinstall": "node ./bin/setup.js",
     "textlint": "textlint docs/**/*.md README.md"
   }


### PR DESCRIPTION
Without the quotes, the glob is resolved by the OS, at least on Macs. Because of that, the `./test/unit/plugins-client-bundle-test.js` test was not run and the coverage fell when run locally, while it was still 100% on travis