### PR TITLE
fix: support npm5’s --save default for postinstall script

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -4,13 +4,9 @@ var path = require('path')
 var fs = require('fs')
 var log = require('npmlog')
 
-// use process.env to access npm config environment variables.
-// - https://docs.npmjs.com/misc/config#environment-variables
-// - https://docs.npmjs.com/misc/config#save
-var saveRequested = process.env.npm_config_save
-
-// This block only executes if Hoodie is installed with `-S` or `--save` flags.
-if (saveRequested) {
+var installIntoApp = process.env.PWD.indexOf('node_modules') !== -1
+// This block only executes if Hoodie is installed with as a dependency
+if (installIntoApp) {
   var pathToAppRoot = path.resolve('..', '..')
   var packageJson = require(path.join(pathToAppRoot, 'package.json'))
 


### PR DESCRIPTION
We now check PWD for `node_modules`, i.e.: we are only
in `node_modules` if we are doing `npm install hoodie`
somewhere, but not when running `npm install` in the
hoodie source directory.

Closes https://github.com/hoodiehq/hoodie/issues/746