### PR TITLE
support hoodie install with linked node_modules folder

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -4,10 +4,11 @@ var path = require('path')
 var fs = require('fs')
 var log = require('npmlog')
 
-var installIntoApp = process.env.PWD.indexOf('node_modules') !== -1
+var workingDirectory = process.env.PWD
+var installIntoApp = /node_modules/.test(workingDirectory)
 // This block only executes if Hoodie is installed with as a dependency
 if (installIntoApp) {
-  var pathToAppRoot = path.resolve('..', '..')
+  var pathToAppRoot = path.resolve(workingDirectory, '..', '..')
   var packageJson = require(path.join(pathToAppRoot, 'package.json'))
 
   packageJson.scripts = packageJson.scripts || {}


### PR DESCRIPTION
closes #751. 

To test it

```
mkdir proxy
mkdir proxy/node_modules
mkdir app
cd app
ln -nsf ../proxy/node_modules node_modules
npm init -y
npm i -S hoodiehq/hoodie#751/setup-with-linked-node-modules-folder
```

I just tried it with my computer (node v6.9.5, npm 3.10.10) and it failed with the same error as descried in #751. Did I miss something @parallaxeffect?