### PR TITLE
pass `options.client` to `Hoodie` client constructor

### DIFF
--- a/cli/hoodie-defaults.js
+++ b/cli/hoodie-defaults.js
@@ -6,6 +6,7 @@ function getHoodieDefaults () {
     port: 8080,
     data: '.hoodie',
     public: 'public',
+    client: {},
     dbUrl: undefined,
     dbUrlPassword: undefined,
     dbUrlUsername: undefined,

--- a/cli/options.js
+++ b/cli/options.js
@@ -120,6 +120,7 @@ function getCliOptions (projectPath) {
   }
 
   options.public = webrootLocator(options.public)
+  options.client = defaults.client
 
   // rc & yargs are setting keys we are not interested in, like in-memory or _
   // so we only pick the relevant ones based on they keys of the default options.

--- a/cli/parse-options.js
+++ b/cli/parse-options.js
@@ -35,7 +35,8 @@ function parseOptions (options) {
       data: options.data,
       public: options.public
     },
-    inMemory: Boolean(options.inMemory)
+    inMemory: Boolean(options.inMemory),
+    client: options.client
   }
 
   log.level = config.loglevel

--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -83,12 +83,21 @@ function buildBundle (config, plugins, callback) {
 
   hoodieBundleSource += 'var Hoodie = require("@hoodie/client")\n'
   hoodieBundleSource += 'var options = {\n'
+
+  if (config.client) {
+    Object.keys(config.client).forEach(function (key) {
+      hoodieBundleSource += '  "' + key + '": ' + JSON.stringify(config.client[key]) + ',\n'
+    })
+  }
+
   if (config.url) {
     hoodieBundleSource += '  url: "' + config.url + '",\n'
   } else {
     hoodieBundleSource += '  url: location.origin,\n'
   }
+
   hoodieBundleSource += '  PouchDB: require("pouchdb-browser")\n'
+
   hoodieBundleSource += '}\n'
   hoodieBundleSource += 'module.exports = new Hoodie(options)\n'
   plugins.forEach(function (pluginPath) {

--- a/test/unit/cli/hoodie-default-test.js
+++ b/test/unit/cli/hoodie-default-test.js
@@ -8,6 +8,7 @@ test('hoodie defaults test', function (group) {
     t.deepEqual(defaults, {
       address: '127.0.0.1',
       adminPassword: undefined,
+      client: {},
       data: '.hoodie',
       dbAdapter: 'pouchdb-adapter-fs',
       dbUrl: undefined,

--- a/test/unit/plugins-client-bundle-test.js
+++ b/test/unit/plugins-client-bundle-test.js
@@ -99,12 +99,16 @@ test('bundle client', function (group) {
     })
 
     bundleClient('client.js', 'bundle.js', {
-      url: 'https://myapp.com'
+      url: 'https://myapp.com',
+      client: {
+        foo: 'bar'
+      }
     }, function (error, buffer) {
       t.error(error)
 
       var expected = 'var Hoodie = require("@hoodie/client")\n' +
                      'var options = {\n' +
+                     '  "foo": "bar",\n' +
                      '  url: "https://myapp.com",\n' +
                      '  PouchDB: require("pouchdb-browser")\n' +
                      '}\n' +


### PR DESCRIPTION
closes #762