### PR TITLE
docs: fix issue with hapi docs display closes #790

### DIFF
--- a/docs/guides/hapi-plugin.rst
+++ b/docs/guides/hapi-plugin.rst
@@ -4,9 +4,13 @@ Using Hoodie as hapi plugin
 Here is an example usage of Hoodie as a hapi plugin:
 
 .. code:: js
+
     var Hapi = require('hapi')
     var hoodie = require('hoodie').register
-
+    var PouchDB = require('pouchdb-core')
+    .plugin(require('pouchdb-mapreduce'))
+    .plugin(require('pouchdb-adapter-memory'))
+  
     var server = new Hapi.Server()
     server.connection({
       host: 'localhost',
@@ -17,7 +21,8 @@ Here is an example usage of Hoodie as a hapi plugin:
       register: hoodie,
       options: { // pass options here
         inMemory: true,
-        public: 'dist'
+        public: 'dist',
+        PouchDB: PouchDB
       }
     }, function (error) {
       if (error) {
@@ -29,7 +34,7 @@ Here is an example usage of Hoodie as a hapi plugin:
           throw error
         }
 
-        console.log(('Server running at:', server.info.uri)
+        console.log(('Server running at:', server.info.uri))
       })
     })
 

--- a/docs/guides/hapi-plugin.rst
+++ b/docs/guides/hapi-plugin.rst
@@ -8,8 +8,8 @@ Here is an example usage of Hoodie as a hapi plugin:
     var Hapi = require('hapi')
     var hoodie = require('hoodie').register
     var PouchDB = require('pouchdb-core')
-    .plugin(require('pouchdb-mapreduce'))
-    .plugin(require('pouchdb-adapter-memory'))
+      .plugin(require('pouchdb-mapreduce'))
+      .plugin(require('pouchdb-adapter-memory'))
   
     var server = new Hapi.Server()
     server.connection({


### PR DESCRIPTION
fixes #790 

* missing space blank line after ``.. code:: js``   
*  fixed console.log missing bracket )  
* added pouchdb and pouchdb to options - Please Check this is correct