### PR TITLE
fix(package): update h2o2 to version 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "browserify": "^14.0.0",
     "good": "^7.0.2",
     "good-squeeze": "^5.0.0",
-    "h2o2": "^6.0.0",
+    "h2o2": "^7.0.1",
     "hapi": "^16.4.2",
     "hapi-cors-headers": "^1.0.0",
     "inert": "^4.0.0",


### PR DESCRIPTION
Closes #823 @@ -18,7 +18,7 @@
     " browserify " : " ^ 14.0.0 " ,
     " good " : " ^ 7.0.2 " ,
     "บีบดี" : " ^ 5.0.0 " ,
-     " h2o2 " : " ^ 6 .0. 0 " ,
+     " h2o2 " : " ^ 7 .0. 1 " ,
     " hapi " : " ^ 16.4.2 " ,
     " hapi-cors-headers " : " ^ 1.0.0 " ,
     " inert " : " ^ 4.0.0 " ,
