### PR TITLE
Fix client plugins crashing hoodie server in Windows

### DIFF
--- a/server/plugins/client/bundle.js
+++ b/server/plugins/client/bundle.js
@@ -34,6 +34,7 @@ function bundleClient (hoodieClientPath, bundleTargetPath, options, callback) {
 
   var plugins = [path.resolve('hoodie/client')]
     .concat(pluginPaths)
+    .map(p => p.replace(/\\/g,"/") )  // fix backslashes in Windows paths
     .filter(checkModule)
 
   var getPluginsModifiedTimes = plugins.map(function (pluginPath) {


### PR DESCRIPTION
In Windows, adding a client plugin as described in `http://docs.hood.ie/en/latest/guides/plugins.html` will crash hoodie server with error:

> Error: Cannot find module 'C:UsersUserdevhoodie-serverhoodieclient' 

as backslashes in Windows paths are collapsed when building the string `hoodieBundleSource`. 

The fix replaces backslashes in the client plugins paths with forward slashes, which work both in Linux and Windows.