### PR TITLE
Upgrage Node.js v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ branches:
 jobs:
   include:
     - stage: test
-      node_js: 4
+      node_js: 6
       script: 
         - npm run test
         - npm run coverage
-    - node_js: 4
+    - node_js: 6
       script: bin/quick-start-test.sh
     - stage: docs
       node_js: lts/*


### PR DESCRIPTION
The test fails because you use the default parameter(support in Node.js v6)