### PR TITLE
Portability #872

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "coverage": "tap --coverage-report=text-lcov | coveralls",
     "semantic-release": "semantic-release",
-    "start": "./bin/start.js",
+    "start": "node start.js",
     "pretest": "standard",
     "test": "tap --100 --jobs-auto './test/{unit,integration}/**/*-test.js'",
     "postinstall": "node ./bin/setup.js",

--- a/start.js
+++ b/start.js
@@ -1,0 +1,20 @@
+var spawn = require('child_process').spawn
+var os = require('os')
+var start
+
+function onLog (data) {
+  console.log(data.toString())
+}
+
+function onError (data) {
+  console.error(data.toString())
+}
+
+if (os.type() === 'Linux') {
+  start = spawn('./bin/start.js')
+} else if (os.type() === 'Windows_NT') {
+  start = spawn('node', ['bin\\start.js'])
+}
+
+start.stdout.on('data', onLog)
+start.stderr.on('data', onError)

--- a/start.js
+++ b/start.js
@@ -15,10 +15,6 @@ if (os.type() === 'Windows_NT') {
 } else {
   start = spawn('./bin/start.js')
 }
-  start = spawn('./bin/start.js')
-} else if (os.type() === 'Windows_NT') {
-  start = spawn('node', ['bin\\start.js'])
-}
 
 start.stdout.on('data', onLog)
 start.stderr.on('data', onError)

--- a/start.js
+++ b/start.js
@@ -10,7 +10,11 @@ function onError (data) {
   console.error(data.toString())
 }
 
-if (os.type() === 'Linux') {
+if (os.type() === 'Windows_NT') {
+  start = spawn('node', ['bin\\start.js'])
+} else {
+  start = spawn('./bin/start.js')
+}
   start = spawn('./bin/start.js')
 } else if (os.type() === 'Windows_NT') {
   start = spawn('node', ['bin\\start.js'])

--- a/start.js
+++ b/start.js
@@ -1,0 +1,20 @@
+var spawn = require('child_process').spawn
+var os = require('os')
+var start
+
+function onLog (data) {
+  console.log(data.toString())
+}
+
+function onError (data) {
+  console.error(data.toString())
+}
+
+if (os.type() === 'Linux') {
+  start = spawn('./bin/start.js')
+} else if (os.type() === 'Windows_NT') {
+  start = spawn('bin\\start.js')
+}
+
+start.stdout.on('data', onLog)
+start.stderr.on('data', onError)


### PR DESCRIPTION
I fixed #872 npm start for Windows by adding portable script.js in package.json.