### PR TITLE
docs: Add 'dependencies' field in package.json

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -67,7 +67,10 @@ like this
       },
       "keywords": [],
       "author": "",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "hoodie": "^28.2.10"
+      }
     }
 
 Now you can start Hoodie with


### PR DESCRIPTION
Add `dependencies` field in the quickstart `package.json` example to make it more accurate.