### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cli/parse-options.js
+++ b/cli/parse-options.js
@@ -19,7 +19,7 @@ var createAuthDbUrl = require('./utils/create-auth-dbUrl')
  * app’s package.json (on the `"hoodie"` key).
  *
  * The parsing of the database configuration is a bit more complex. If `dbUrl`
- * is passed it means that a remote CouchDB is used for persistance, otherwise
+ * is passed it means that a remote CouchDB is used for persistence, otherwise
  * PouchDB is being used. A shortcut to set PouchDB’s adapter to memdown is to
  * passe set the `inMemory: true` option. If it’s not set, leveldown is used
  * with the prefix set to `options.data` + 'data' (`.hoodie/data` by default).

--- a/cli/utils/create-auth-dbUrl.js
+++ b/cli/utils/create-auth-dbUrl.js
@@ -8,7 +8,7 @@ module.exports = createAuthDbUrl
  * @param dbPassword used for parsing options.dbUrlPassword
  * @param dbUrl used for parsing options.dbUrl
  *
- * @var dbUrlParts contains different parts of dbUrl, helping in modifing username and password
+ * @var dbUrlParts contains different parts of dbUrl, helping in modifying username and password
  *
  * @returns dbUrl based on the parameters
  * @throws Error if dbUrl is unparsable or authDetails are missing

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -37,7 +37,7 @@ working with on the client side. It consists of:
    which lets you do user authentication, such as signing users up, in
    and out
 -  `The store API <client/hoodie.store.html>`__,
-   which provides means to store and retrieve data for each individial
+   which provides means to store and retrieve data for each individual
    user
 -  `The connectionStatus API <client/hoodie.connection-status.html>`__,
    which provides helpers for connectivity.

--- a/docs/developers/DOCS_STYLE.rst
+++ b/docs/developers/DOCS_STYLE.rst
@@ -79,7 +79,7 @@ The current tests we run on pull requests using Travis Continuous Integration (C
 Bonus style points
 ~~~~~~~~~~~~~~~~~~
 - Be fun and friendly as long as it does not distract or confuse the reader
-- Include videos or gifs to demostrated a feature
+- Include videos or gifs to demonstrated a feature
 - You can use Humour but remember the reader is looking for an *answer* not a comedy sketch
 - Cultural references and puns don't always translate - keep jokes light
 - Remember English is not the first language for many readers - keep language simple where possible


### PR DESCRIPTION
There are small typos in:
- cli/parse-options.js
- cli/utils/create-auth-dbUrl.js
- docs/api/index.rst
- docs/developers/DOCS_STYLE.rst

Fixes:
- Should read `persistence` rather than `persistance`.
- Should read `modifying` rather than `modifing`.
- Should read `individual` rather than `individial`.
- Should read `demonstrated` rather than `demostrated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md