### PR TITLE
Fix dependency badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Build Status](https://travis-ci.org/hoodiehq/hoodie.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie)
 [![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie/badge.svg?branch=master)](https://coveralls.io/github/hoodiehq/hoodie?branch=master)
-[![Dependency Status](https://david-dm.org/hoodiehq/hoodie.svg)](https://david-dm.org/hoodiehq/hoodie)
-[![devDependency Status](https://david-dm.org/hoodiehq/hoodie/dev-status.svg)](https://david-dm.org/hoodiehq/hoodie#info=devDependencies)
+[![Known Vulnerabilities](https://snyk.io/test/github/hoodiehq/hoodie/badge.svg)](https://snyk.io/test/github/hoodiehq/hoodie)
+[![Dependency Status](https://img.shields.io/librariesio/github/hoodiehq/hoodie)](https://libraries.io/github/hoodiehq/hoodie)
 
 <a href="http://hood.ie/animals/#low-profile-dog"><img src="https://avatars1.githubusercontent.com/u/1888826?v=3&s=200"
  alt="The Low-Profile Dog Hoodie Mascot" title="The Low-Profile Dog Hoodie Mascot" align="right" /></a>


### PR DESCRIPTION


This pull request addresses the issue of broken dependency badges in the [README.md](vscode-file://vscode-app/private/var/folders/dn/x5wbgyg95pq7m9zmrffg_czc0000gn/T/AppTranslocation/FAB7EEE6-6158-40A6-BAE4-5299ECCB88D9/d/Visual%20Studio%20Code%202.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) file. The outdated David DM badges have been replaced with reliable alternatives:

Snyk Badge: Tracks known vulnerabilities in the repository.
Libraries.io Badge: Provides up-to-date dependency status.
These changes ensure that the badges are functional and provide accurate information about the project's dependencies and security.

## **Before:**
![Before Screenshot](https://github.com/user-attachments/assets/7195db87-5587-489f-98ce-e1289493e43f)

## **After:**
![After Screenshot](https://github.com/user-attachments/assets/6abd18fc-8aaf-4e3f-a4a0-c7a587cf5b8c)